### PR TITLE
fix: geocoder autocomplete not showing any addresses

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
           sed -i 's|<base href="/">|<base href="/web/">|' build/web/index.html
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: flutter-web-build
           path: ./flutter_frontend/multimodal_routeplanner/build/web
@@ -63,7 +63,8 @@ jobs:
           mkdir -p ./flask_app/templates
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/upload-artifact@v4
+
         with:
           name: flutter-web-build
           path: ./flask_app/templates/

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/helpers/mode_mapping_helper.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/helpers/mode_mapping_helper.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:logger/logger.dart';
 import 'package:multimodal_routeplanner/03_domain/entities/MobilityMode.dart';
 import 'package:multimodal_routeplanner/03_domain/enums/MobilityModeEnum.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/logger.dart';
 
 class ModeMappingHelper {

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v1/widgets/map/RouteMarker.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v1/widgets/map/RouteMarker.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/mode_mapping_helper.dart';
 import 'package:multimodal_routeplanner/03_domain/entities/Trip.dart';
 import 'package:multimodal_routeplanner/03_domain/enums/RouteMarkerTypeEnum.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 
 class RouteMarker extends StatelessWidget {
   final Trip trip;

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v1/widgets/map/StartMarker.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v1/widgets/map/StartMarker.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/mode_mapping_helper.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 
 class StartMarker extends StatelessWidget {
   const StartMarker({super.key, required this.mode});

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v1/widgets/route_info/RouteInfo.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v1/widgets/route_info/RouteInfo.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/mode_mapping_helper.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/string_formatting_helper.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v1/widgets/route_info/ExternalCostsDetailRow.dart';
@@ -8,6 +7,7 @@ import 'package:multimodal_routeplanner/02_application/bloc/route_info/info_drop
 import 'package:multimodal_routeplanner/02_application/bloc/route_info/info_dropdown_mobiscore_cubit.dart';
 import 'package:multimodal_routeplanner/02_application/bloc/route_info/route_info_bloc.dart';
 import 'package:multimodal_routeplanner/03_domain/entities/Trip.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 
 class RouteInfo extends StatelessWidget {
   final Trip trip;

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v1/widgets/search_page/mode_input/SelectionIconButton.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v1/widgets/search_page/mode_input/SelectionIconButton.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/mode_mapping_helper.dart';
 import 'package:multimodal_routeplanner/02_application/bloc/route_planner/advanced_route_planner_bloc.dart';
 import 'package:multimodal_routeplanner/03_domain/entities/MobilityMode.dart';
 import 'package:multimodal_routeplanner/03_domain/entities/Trip.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 
 class AdvancedSelectionIconButton extends StatelessWidget {
   final MobilityMode mode;

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v1/widgets/search_page/result_list/result_list_item/ResultListItem.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v1/widgets/search_page/result_list/result_list_item/ResultListItem.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/mode_mapping_helper.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/string_formatting_helper.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v1/widgets/search_page/result_list/result_list_item/RouteIndicator.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/ResultScreen.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/ResultScreen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/headers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/ResultSection.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/fullcost_calculator/search_screen/SearchScreen.dart';
 import 'package:multimodal_routeplanner/02_application/bloc/sasim_2/trips_cubit.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 
 class ResultScreen extends StatelessWidget {
   const ResultScreen({super.key, required this.startAddress, required this.endAddress});
@@ -25,8 +25,7 @@ class ResultScreen extends StatelessWidget {
         child: Column(
           children: [
             TitleImage(
-                imagePath: 'assets/title_image/titelbild_ubahn.png',
-                titleText: lang.that_are_the_true_costs_header),
+                imagePath: 'assets/title_image/titelbild_ubahn.png', titleText: lang.that_are_the_true_costs_header),
             fromToHeader(context, lang),
             BlocBuilder<TripsCubit, TripsState>(
               builder: (context, state) {
@@ -85,10 +84,7 @@ class ResultScreen extends StatelessWidget {
               ),
               child: Text(lang.new_route,
                   textAlign: TextAlign.center,
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodyLarge!
-                      .copyWith(color: colorScheme.onPrimaryContainer)),
+                  style: Theme.of(context).textTheme.bodyLarge!.copyWith(color: colorScheme.onPrimaryContainer)),
             ),
           )
         ],
@@ -104,10 +100,7 @@ class ResultScreen extends StatelessWidget {
       children: [
         Text(
           label,
-          style: Theme.of(context)
-              .textTheme
-              .titleMedium!
-              .copyWith(color: contentColor, fontWeight: FontWeight.bold),
+          style: Theme.of(context).textTheme.titleMedium!.copyWith(color: contentColor, fontWeight: FontWeight.bold),
         ),
         Text(
           address,

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/ResultSection.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/ResultSection.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/headers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/ResultTable.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/ResultTable.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/ResultTable.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/custom_scrollbar.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/values.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/table_cells/CostsItem.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/general_result_diagram/ExternalCostsDiagram.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/general_result_diagram/ExternalCostsDiagram.dart
@@ -1,6 +1,6 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:logger/logger.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/values.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/general_result_diagram/build_main_result_diagram.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/general_result_diagram/build_main_result_diagram.dart
@@ -2,7 +2,7 @@ import 'dart:math';
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/mode_mapping_helper.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/general_result_diagram/ExternalCostsDiagram.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/table_cells/HeaderItem.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/table_cells/HeaderItem.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/mode_mapping_helper.dart';
 import 'package:multimodal_routeplanner/03_domain/entities/Trip.dart';
 

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/table_cells/MobiScoreItem.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/table_cells/MobiScoreItem.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/mode_mapping_helper.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/table_cells/CustomAnimatedTableCell.dart';
 import 'package:multimodal_routeplanner/03_domain/entities/Trip.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/table_cells/TripInfoItem.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/table_cells/TripInfoItem.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:logger/logger.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/mode_mapping_helper.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/search_screen/SearchScreen.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/fullcost_calculator/search_screen/SearchScreen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/headers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/fullcost_calculator/result_screen/ResultScreen.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/main_screen.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v2/main_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:multimodal_routeplanner/01_presentation/commons/mcube_logo.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/commons/information_bottom_row.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/commons/information_bottom_row.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/about_us/data_protection_screen.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/commons/logos.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/commons/logos.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:multimodal_routeplanner/01_presentation/commons/mcube_logo.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/commons/nav_drawer.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/commons/nav_drawer.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:multimodal_routeplanner/01_presentation/commons/mcube_logo.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/commons/navigation_header.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/commons/navigation_header.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/logos.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/helpers/mode_to_x.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/helpers/mode_to_x.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 
 IconData getIconDataFromMode(String mode, {bool isOutlined = true}) {
   switch (mode) {

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/about_us/about_us_content.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/about_us/about_us_content.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/information_bottom_row.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/v3_scaffold.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/about_us/data_protection_screen.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/about_us/data_protection_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/v3_scaffold.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/about_us/text_formating_helper.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/about_us/imprint_screen.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/about_us/imprint_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/v3_scaffold.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/about_us/text_formating_helper.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/research/research_content.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/research/research_content.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/information_bottom_row.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/v3_scaffold.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/detail_route_info/detail_route_info_content.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/detail_route_info/detail_route_info_content.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/helpers/mode_mapping_helper.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/detail_route_info/detail_route_info_map.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/detail_route_info/detail_route_info_diagram.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/detail_route_info/detail_route_info_diagram.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/detail_route_info/detail_route_info_content.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/detail_route_info/diagram/diagram_helper_methods.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/detail_route_info/diagram/stacked_diagram_bar.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/detail_route_info/detail_route_info_mobiscore.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/detail_route_info/detail_route_info_mobiscore.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/widgets/mobiscore_score_board/mobi_score_score_board.dart';
 

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/detail_route_info/diagram/detail_route_text_info.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/detail_route_info/diagram/detail_route_text_info.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/detail_route_info/detail_route_info_content.dart';
 import 'package:multimodal_routeplanner/01_presentation/theme_data/typography.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/detail_route_info/diagram/diagram_content.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/detail_route_info/diagram/diagram_content.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/detail_route_info/detail_route_info_content.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/detail_route_info/detail_route_info_diagram.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/detail_route_info/diagram/diagram_helper_methods.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/detail_route_info/diagram/diagram_helper_methods.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/helpers/costs_rates.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/detail_route_info/detail_route_info_content.dart';
 import 'package:multimodal_routeplanner/03_domain/entities/Trip.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/layer_1/layer_1_content.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/layer_1/layer_1_content.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/buttons.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/selection_mode.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/layer_2_detailed/costs_card_layer_2.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/layer_2_detailed/costs_card_layer_2.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/helpers/mobiscore_to_x.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/layer_2_detailed/values.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/layer_2_detailed/costs_details_card_layer_2.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/layer_2_detailed/costs_details_card_layer_2.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/helpers/costs_category_to_image.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/layer_2_detailed/values.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/layer_2_detailed/layer_2_content_desktop.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/layer_2_detailed/layer_2_content_desktop.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/buttons.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/layer_2_detailed/layer_2_content_mobile.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/layer_2_detailed/layer_2_content_mobile.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/buttons.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/result_content.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/result_content.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/buttons.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/result_screen_v3.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/result_screen_v3.dart
@@ -4,7 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logger/logger.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/widgets/costs_percentage_bar.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/widgets/costs_percentage_bar.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/helpers/colors_helper.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/helpers/costs_rates.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/widgets/costs_result_column_1.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/result/widgets/costs_result_column_1.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/widgets/question_icons.dart';
 import 'package:multimodal_routeplanner/03_domain/entities/Trip.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/search_content.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/search_content.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/search/values.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/search/widgets/search_input_container.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/search_screen_v3.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/search_screen_v3.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/buttons.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/information_bottom_row.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/address_input/address_input_components.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/address_input/address_input_components.dart
@@ -68,6 +68,8 @@ BlocBuilder<AddressPickerBloc, AddressPickerState> startAddressPickerBuilder(Add
                   addressPickerBloc.add(PickStartAddress(address));
                   onAddressSelectedCallback(address, lat, lon);
                 });
+          } else if (state is StartAddressEmpty) {
+            return const SizedBox();
           } else {
             return addressNotFoundItem(context);
           }
@@ -96,6 +98,8 @@ BlocBuilder<AddressPickerBloc, AddressPickerState> endAddressPickerBuilder(
                   addressPickerBloc.add(PickEndAddress(address));
                   onAddressSelectedCallback(address, lat, lon);
                 });
+          } else if (state is EndAddressEmpty) {
+            return const SizedBox();
           } else {
             return addressNotFoundItem(context);
           }

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/address_input/address_picker_list.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/address_input/address_picker_list.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/03_domain/entities/address_picker/Address.dart';
 

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/address_input/desktop_address_input_row.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/address_input/desktop_address_input_row.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logger/logger.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/address_input/input_validation.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/address_input/input_validation.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 
 String? validateInput(BuildContext context, String? value) {
   AppLocalizations lang = AppLocalizations.of(context)!;

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/address_input/mobile_address_input_container.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/address_input/mobile_address_input_container.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/buttons.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/custom_switch.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/custom_switch.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/theme_data/colors_v3.dart';
 import 'package:multimodal_routeplanner/02_application/bloc/app_cubit.dart';
 

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/electric_selection_components.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/electric_selection_components.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/theme_data/colors_v3.dart';
 

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/search_input_container.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/search_input_container.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/selection_mode.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/result/result_cubit.dart';
@@ -9,6 +8,7 @@ import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/pages/s
 import 'package:multimodal_routeplanner/01_presentation/theme_data/colors_v3.dart';
 import 'package:multimodal_routeplanner/01_presentation/theme_data/typography.dart';
 import 'package:multimodal_routeplanner/config/setup_dependencies.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 
 class SearchInputContent extends StatefulWidget {
   const SearchInputContent({

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/shared_selection_components.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/search/widgets/shared_selection_components.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/theme_data/colors_v3.dart';
 import 'package:multimodal_routeplanner/01_presentation/theme_data/typography.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/share/share_content.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/route_planner_v3/pages/share/share_content.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/commons/spacers.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v3/commons/buttons.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/01_presentation/values/desription_texts.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/01_presentation/values/desription_texts.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:multimodal_routeplanner/l10n/app_localizations.dart';
 import 'package:logger/logger.dart';
 import 'package:multimodal_routeplanner/01_presentation/route_planner_v2/fullcost_calculator/result_screen/results_section/general_result_diagram/ExternalCostsDiagram.dart';
 import 'package:multimodal_routeplanner/logger.dart';

--- a/flutter_frontend/multimodal_routeplanner/lib/02_application/bloc/address_picker/address_picker_bloc.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/02_application/bloc/address_picker/address_picker_bloc.dart
@@ -11,6 +11,7 @@ part 'address_picker_state.dart';
 
 class AddressPickerBloc extends Bloc<AddressPickerEvent, AddressPickerState> {
   final AddressPickerUsecases addressPickerUsecases;
+
   AddressPickerBloc(this.addressPickerUsecases) : super(AddressPickerInitial()) {
     Logger logger = getLogger();
 
@@ -31,9 +32,17 @@ class AddressPickerBloc extends Bloc<AddressPickerEvent, AddressPickerState> {
                 (element) => element.properties.city != 'München' && element.properties.country != 'Deutschland');
 
             if (event is StartAddressInputChanged) {
-              emit(StartAddressRetrieved(listAddresses));
+              if (event.addressInput.isEmpty) {
+                emit(StartAddressEmpty());
+              } else {
+                emit(StartAddressRetrieved(listAddresses));
+              }
             } else if (event is EndAddressInputChanged) {
-              emit(EndAddressRetrieved(listAddresses));
+              if (event.addressInput.isEmpty) {
+                emit(EndAddressEmpty());
+              } else {
+                emit(EndAddressRetrieved(listAddresses));
+              }
             }
           } catch (e) {
             if (event is StartAddressInputChanged) {

--- a/flutter_frontend/multimodal_routeplanner/lib/02_application/bloc/address_picker/address_picker_state.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/02_application/bloc/address_picker/address_picker_state.dart
@@ -40,3 +40,7 @@ class EndAddressPicked implements AddressPicked {}
 class StartAddressError extends AddressPickerState {}
 
 class EndAddressError extends AddressPickerState {}
+
+class StartAddressEmpty extends AddressPickerState {}
+
+class EndAddressEmpty extends AddressPickerState {}

--- a/flutter_frontend/multimodal_routeplanner/lib/03_domain/usecases/address_picker_usecases.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/03_domain/usecases/address_picker_usecases.dart
@@ -10,7 +10,9 @@ class AddressPickerUsecases {
 
     // only keep elements, where Address.Properties.city at least contains or is "München"
     addressList = addressList
-        .where((element) => element.properties.city != null && element.properties.city!.contains('München'))
+        .where((element) =>
+            element.properties.city != null &&
+            (element.properties.city!.contains('München') || element.properties.city!.contains('Munich')))
         .toList();
 
     return addressList;

--- a/flutter_frontend/multimodal_routeplanner/lib/04_infrastructure/datasources/photon_address_picker_datasource.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/04_infrastructure/datasources/photon_address_picker_datasource.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:logger/logger.dart';
 import 'package:multimodal_routeplanner/03_domain/entities/address_picker/Address.dart';
+import 'package:multimodal_routeplanner/logger.dart';
 
 abstract class PhotonGeocoderDatasource {
   Future<List<Address>> getListAddressesFromApi({required String inputAddress});
@@ -14,14 +16,16 @@ class PhotonGeocoderDatasourceImpl implements PhotonGeocoderDatasource {
   final String munichLat = 48.1371695.toString();
   final String munichLon = 11.571096.toString();
 
+  Logger logger = getLogger();
+
   @override
-  Future<List<Address>> getListAddressesFromApi(
-      {required String inputAddress}) async {
-    var url =
-        'https://photon.komoot.io/api/?q=$inputAddress&lang=de&lat=$munichLat&lon=$munichLon';
+  Future<List<Address>> getListAddressesFromApi({required String inputAddress}) async {
+    var url = 'https://photon.komoot.io/api/?q=$inputAddress&lang=de&lat=$munichLat&lon=$munichLon';
 
     final response = await client.get(Uri.parse(url));
-    final responseBody = json.decode(response.body)['features'];
+
+    // Decode response body as UTF-8 to handle special characters correctly
+    final responseBody = json.decode(utf8.decode(response.bodyBytes))['features'];
 
     final List<Address> listAddresses = [];
     responseBody.forEach((element) {

--- a/flutter_frontend/multimodal_routeplanner/lib/l10n/app_localizations.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/l10n/app_localizations.dart
@@ -1,0 +1,1497 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_de.dart';
+import 'app_localizations_en.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
+///
+/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: AppLocalizations.localizationsDelegates,
+///   supportedLocales: AppLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// property.
+abstract class AppLocalizations {
+  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static AppLocalizations? of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations);
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('de'),
+    Locale('en')
+  ];
+
+  /// No description provided for @that_are_the_true_costs_header.
+  ///
+  /// In en, this message translates to:
+  /// **'These are the true costs of your mobility'**
+  String get that_are_the_true_costs_header;
+
+  /// No description provided for @these_are_external_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'These are the external costs of your route'**
+  String get these_are_external_costs;
+
+  /// No description provided for @what_is_mobi_score.
+  ///
+  /// In en, this message translates to:
+  /// **'What is the Mobi-Score?'**
+  String get what_is_mobi_score;
+
+  /// No description provided for @calculator.
+  ///
+  /// In en, this message translates to:
+  /// **'Calculator'**
+  String get calculator;
+
+  /// No description provided for @information.
+  ///
+  /// In en, this message translates to:
+  /// **'Information'**
+  String get information;
+
+  /// No description provided for @about_us.
+  ///
+  /// In en, this message translates to:
+  /// **'About Us'**
+  String get about_us;
+
+  /// No description provided for @start_address.
+  ///
+  /// In en, this message translates to:
+  /// **'Start Address'**
+  String get start_address;
+
+  /// No description provided for @end_address.
+  ///
+  /// In en, this message translates to:
+  /// **'Destination Address'**
+  String get end_address;
+
+  /// No description provided for @please_insert_address.
+  ///
+  /// In en, this message translates to:
+  /// **'Please insert address'**
+  String get please_insert_address;
+
+  /// No description provided for @from.
+  ///
+  /// In en, this message translates to:
+  /// **'From'**
+  String get from;
+
+  /// No description provided for @from_hint.
+  ///
+  /// In en, this message translates to:
+  /// **'From (e.g. Arcisstraße 21, München)'**
+  String get from_hint;
+
+  /// No description provided for @to.
+  ///
+  /// In en, this message translates to:
+  /// **'To'**
+  String get to;
+
+  /// No description provided for @to_hint.
+  ///
+  /// In en, this message translates to:
+  /// **'To (e.g. Ostbahnhof, München)'**
+  String get to_hint;
+
+  /// No description provided for @new_route.
+  ///
+  /// In en, this message translates to:
+  /// **'New Route'**
+  String get new_route;
+
+  /// No description provided for @show_route.
+  ///
+  /// In en, this message translates to:
+  /// **'Show Route'**
+  String get show_route;
+
+  /// No description provided for @car.
+  ///
+  /// In en, this message translates to:
+  /// **'Car'**
+  String get car;
+
+  /// No description provided for @ecar.
+  ///
+  /// In en, this message translates to:
+  /// **'Electric Car'**
+  String get ecar;
+
+  /// No description provided for @bike.
+  ///
+  /// In en, this message translates to:
+  /// **'Bike'**
+  String get bike;
+
+  /// No description provided for @ebike.
+  ///
+  /// In en, this message translates to:
+  /// **'Electric Bike'**
+  String get ebike;
+
+  /// No description provided for @moped.
+  ///
+  /// In en, this message translates to:
+  /// **'Moped'**
+  String get moped;
+
+  /// No description provided for @e_moped.
+  ///
+  /// In en, this message translates to:
+  /// **'Electric Moped'**
+  String get e_moped;
+
+  /// No description provided for @tier.
+  ///
+  /// In en, this message translates to:
+  /// **'TIER E-Scooter'**
+  String get tier;
+
+  /// No description provided for @cab.
+  ///
+  /// In en, this message translates to:
+  /// **'Call a Bike'**
+  String get cab;
+
+  /// No description provided for @flinkster.
+  ///
+  /// In en, this message translates to:
+  /// **'Flinkster'**
+  String get flinkster;
+
+  /// No description provided for @emmy.
+  ///
+  /// In en, this message translates to:
+  /// **'Emmy'**
+  String get emmy;
+
+  /// No description provided for @sharenow.
+  ///
+  /// In en, this message translates to:
+  /// **'Sharenow'**
+  String get sharenow;
+
+  /// No description provided for @pt.
+  ///
+  /// In en, this message translates to:
+  /// **'Public Transport'**
+  String get pt;
+
+  /// No description provided for @metro.
+  ///
+  /// In en, this message translates to:
+  /// **'Metro'**
+  String get metro;
+
+  /// No description provided for @tram.
+  ///
+  /// In en, this message translates to:
+  /// **'Tram'**
+  String get tram;
+
+  /// No description provided for @bus.
+  ///
+  /// In en, this message translates to:
+  /// **'Bus'**
+  String get bus;
+
+  /// No description provided for @e_bus.
+  ///
+  /// In en, this message translates to:
+  /// **'E-Bus'**
+  String get e_bus;
+
+  /// No description provided for @pt_and_bike.
+  ///
+  /// In en, this message translates to:
+  /// **'Public Transport + Bike'**
+  String get pt_and_bike;
+
+  /// No description provided for @walk.
+  ///
+  /// In en, this message translates to:
+  /// **'Walk'**
+  String get walk;
+
+  /// No description provided for @not_available.
+  ///
+  /// In en, this message translates to:
+  /// **'Not Available'**
+  String get not_available;
+
+  /// No description provided for @description_fullcosts.
+  ///
+  /// In en, this message translates to:
+  /// **'The total costs incurred when using a mode of transportation, including both direct and indirect costs such as fuel, maintenance, insurance, and environmental impacts.'**
+  String get description_fullcosts;
+
+  /// No description provided for @description_external_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'Costs incurred by using a mode of transportation but not directly borne by the users. These include environmental damage, health issues, and social costs.'**
+  String get description_external_costs;
+
+  /// No description provided for @description_internal_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'The direct costs borne by users of a mode of transportation, such as fuel costs, maintenance, and insurance.'**
+  String get description_internal_costs;
+
+  /// No description provided for @descripton_accidents.
+  ///
+  /// In en, this message translates to:
+  /// **'Accident costs are the costs arising from personal injuries in accidents. Since physical damage to cars and infrastructure is predominantly covered by motor vehicle insurance or borne by the parties causing the damage, they are not considered here.'**
+  String get descripton_accidents;
+
+  /// No description provided for @description_air.
+  ///
+  /// In en, this message translates to:
+  /// **'The calculation of air pollution costs includes various aspects. These include material damage, crop failure, biodiversity loss, and health damage caused by air pollution.'**
+  String get description_air;
+
+  /// No description provided for @description_noise.
+  ///
+  /// In en, this message translates to:
+  /// **'The effects of noise are noticeable in various areas of life. Thus, traffic noise causes costs for a national economy in several respects.'**
+  String get description_noise;
+
+  /// No description provided for @description_space.
+  ///
+  /// In en, this message translates to:
+  /// **'Transport uses land in two different traffic situations. Land is used for moving traffic via streets or rail systems. At the same time, vehicles that are not moved occupy space for parking.'**
+  String get description_space;
+
+  /// No description provided for @description_congestion.
+  ///
+  /// In en, this message translates to:
+  /// **'Congestion is mostly known for blocked streets by cars and other road users. However, there are also a lot of congested public transport networks which lead to delays. For both cases, time is lost and thus costs are generated.'**
+  String get description_congestion;
+
+  /// No description provided for @description_barrier.
+  ///
+  /// In en, this message translates to:
+  /// **'The barrier effect describes the time delay that motorized transport imposes on active mobility forms. This could be in the form of big streets pedestrians have to cross or circumvent to reach their destination.'**
+  String get description_barrier;
+
+  /// No description provided for @description_environment.
+  ///
+  /// In en, this message translates to:
+  /// **'Costs due to environmental damage include all damages caused today and in the future by climate change, associated with uncertainties. They depend on the propulsion type of the vehicle and include costs from the operation of the vehicle as well as from the fuel and power production.'**
+  String get description_environment;
+
+  /// No description provided for @external_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'external costs'**
+  String get external_costs;
+
+  /// No description provided for @internal_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'internal costs'**
+  String get internal_costs;
+
+  /// No description provided for @fullcosts.
+  ///
+  /// In en, this message translates to:
+  /// **'fullcosts'**
+  String get fullcosts;
+
+  /// No description provided for @accidents.
+  ///
+  /// In en, this message translates to:
+  /// **'accidents'**
+  String get accidents;
+
+  /// No description provided for @air_pollution.
+  ///
+  /// In en, this message translates to:
+  /// **'air pollution'**
+  String get air_pollution;
+
+  /// No description provided for @noise.
+  ///
+  /// In en, this message translates to:
+  /// **'noise'**
+  String get noise;
+
+  /// No description provided for @space_use.
+  ///
+  /// In en, this message translates to:
+  /// **'space use'**
+  String get space_use;
+
+  /// No description provided for @congestion.
+  ///
+  /// In en, this message translates to:
+  /// **'congestion'**
+  String get congestion;
+
+  /// No description provided for @barrier_effects.
+  ///
+  /// In en, this message translates to:
+  /// **'barrier effects'**
+  String get barrier_effects;
+
+  /// No description provided for @environmental_damages.
+  ///
+  /// In en, this message translates to:
+  /// **'environmental\ndamages'**
+  String get environmental_damages;
+
+  /// No description provided for @mobi_score.
+  ///
+  /// In en, this message translates to:
+  /// **'Mobi-Score'**
+  String get mobi_score;
+
+  /// No description provided for @header_external_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'External\nCosts'**
+  String get header_external_costs;
+
+  /// No description provided for @header_internal_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'Internal\nCosts'**
+  String get header_internal_costs;
+
+  /// No description provided for @header_fullcosts.
+  ///
+  /// In en, this message translates to:
+  /// **'Full\nCosts'**
+  String get header_fullcosts;
+
+  /// No description provided for @header_mobi_score.
+  ///
+  /// In en, this message translates to:
+  /// **'Mobi-\nScore'**
+  String get header_mobi_score;
+
+  /// No description provided for @something_went_wrong.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong.'**
+  String get something_went_wrong;
+
+  /// No description provided for @please_try_again.
+  ///
+  /// In en, this message translates to:
+  /// **'Please reload or select a different route.'**
+  String get please_try_again;
+
+  /// No description provided for @try_again.
+  ///
+  /// In en, this message translates to:
+  /// **'Try again'**
+  String get try_again;
+
+  /// No description provided for @research.
+  ///
+  /// In en, this message translates to:
+  /// **'Research'**
+  String get research;
+
+  /// No description provided for @by.
+  ///
+  /// In en, this message translates to:
+  /// **'by'**
+  String get by;
+
+  /// No description provided for @de.
+  ///
+  /// In en, this message translates to:
+  /// **'de'**
+  String get de;
+
+  /// No description provided for @en.
+  ///
+  /// In en, this message translates to:
+  /// **'en'**
+  String get en;
+
+  /// No description provided for @electric.
+  ///
+  /// In en, this message translates to:
+  /// **'Electric'**
+  String get electric;
+
+  /// No description provided for @calculate.
+  ///
+  /// In en, this message translates to:
+  /// **'Calculate'**
+  String get calculate;
+
+  /// No description provided for @error.
+  ///
+  /// In en, this message translates to:
+  /// **'Error'**
+  String get error;
+
+  /// No description provided for @show_detailed_info.
+  ///
+  /// In en, this message translates to:
+  /// **'Detailed Route Information'**
+  String get show_detailed_info;
+
+  /// No description provided for @these_are_the_costs_of_your_journey_with.
+  ///
+  /// In en, this message translates to:
+  /// **'These are the real costs of mobility with'**
+  String get these_are_the_costs_of_your_journey_with;
+
+  /// No description provided for @private_car.
+  ///
+  /// In en, this message translates to:
+  /// **'a private car'**
+  String get private_car;
+
+  /// No description provided for @private_ecar.
+  ///
+  /// In en, this message translates to:
+  /// **'a private electric car'**
+  String get private_ecar;
+
+  /// No description provided for @shared_car.
+  ///
+  /// In en, this message translates to:
+  /// **'car-sharing'**
+  String get shared_car;
+
+  /// No description provided for @private_bike.
+  ///
+  /// In en, this message translates to:
+  /// **'a private bike'**
+  String get private_bike;
+
+  /// No description provided for @private_ebike.
+  ///
+  /// In en, this message translates to:
+  /// **'a private electric bike'**
+  String get private_ebike;
+
+  /// No description provided for @shared_bike.
+  ///
+  /// In en, this message translates to:
+  /// **'bike-sharing'**
+  String get shared_bike;
+
+  /// No description provided for @public_transport.
+  ///
+  /// In en, this message translates to:
+  /// **'public transport'**
+  String get public_transport;
+
+  /// No description provided for @unknown.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown'**
+  String get unknown;
+
+  /// No description provided for @fullcosts_of_trip.
+  ///
+  /// In en, this message translates to:
+  /// **'Fullcosts of the Trip'**
+  String get fullcosts_of_trip;
+
+  /// No description provided for @social_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'Social Costs'**
+  String get social_costs;
+
+  /// No description provided for @social_costs_two_line.
+  ///
+  /// In en, this message translates to:
+  /// **'Social\nCosts'**
+  String get social_costs_two_line;
+
+  /// No description provided for @personal_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'Personal Costs'**
+  String get personal_costs;
+
+  /// No description provided for @personal_costs_two_line.
+  ///
+  /// In en, this message translates to:
+  /// **'Personal\nCosts'**
+  String get personal_costs_two_line;
+
+  /// No description provided for @back_to_results.
+  ///
+  /// In en, this message translates to:
+  /// **'Back'**
+  String get back_to_results;
+
+  /// No description provided for @share.
+  ///
+  /// In en, this message translates to:
+  /// **'Share or Leave some Feedback'**
+  String get share;
+
+  /// No description provided for @time.
+  ///
+  /// In en, this message translates to:
+  /// **'Time'**
+  String get time;
+
+  /// No description provided for @health.
+  ///
+  /// In en, this message translates to:
+  /// **'Health'**
+  String get health;
+
+  /// No description provided for @environment.
+  ///
+  /// In en, this message translates to:
+  /// **'Environment'**
+  String get environment;
+
+  /// No description provided for @fixed.
+  ///
+  /// In en, this message translates to:
+  /// **'Fixed'**
+  String get fixed;
+
+  /// No description provided for @variable.
+  ///
+  /// In en, this message translates to:
+  /// **'Variable'**
+  String get variable;
+
+  /// No description provided for @route_is_loading.
+  ///
+  /// In en, this message translates to:
+  /// **'Routes are loading...'**
+  String get route_is_loading;
+
+  /// No description provided for @learn_about.
+  ///
+  /// In en, this message translates to:
+  /// **'Learn about the true cost of your mobility'**
+  String get learn_about;
+
+  /// No description provided for @input_instructions.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose among the available travel modes and enter a start and end point in Munich to calculate the true costs of your trip.'**
+  String get input_instructions;
+
+  /// No description provided for @total_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'Total Costs'**
+  String get total_costs;
+
+  /// No description provided for @total.
+  ///
+  /// In en, this message translates to:
+  /// **'Total'**
+  String get total;
+
+  /// No description provided for @social.
+  ///
+  /// In en, this message translates to:
+  /// **'Social'**
+  String get social;
+
+  /// No description provided for @overall.
+  ///
+  /// In en, this message translates to:
+  /// **'Overall'**
+  String get overall;
+
+  /// No description provided for @personal.
+  ///
+  /// In en, this message translates to:
+  /// **'Personal'**
+  String get personal;
+
+  /// No description provided for @time_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'Time Costs'**
+  String get time_costs;
+
+  /// No description provided for @health_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'Health Costs'**
+  String get health_costs;
+
+  /// No description provided for @environment_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'Environment Costs'**
+  String get environment_costs;
+
+  /// No description provided for @fixed_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'Fixed Costs'**
+  String get fixed_costs;
+
+  /// No description provided for @variable_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'Variable Costs'**
+  String get variable_costs;
+
+  /// No description provided for @by_mode.
+  ///
+  /// In en, this message translates to:
+  /// **'by mode'**
+  String get by_mode;
+
+  /// No description provided for @total_description.
+  ///
+  /// In en, this message translates to:
+  /// **'The true costs - or full costs - of mobility are the sum of personal costs and external costs. The external costs are not carried by the traveler, but society as a whole.'**
+  String get total_description;
+
+  /// No description provided for @social_description.
+  ///
+  /// In en, this message translates to:
+  /// **'Externalities arise when the activities of a person or company have an impact on third parties that are not included in the price. This effect can be both positive (external benefits) and negative (external costs). \nIn terms of mobility, external costs mean that the costs of transport activities are not carried by the travelers themselves, but by society in general.'**
+  String get social_description;
+
+  /// No description provided for @personal_description.
+  ///
+  /// In en, this message translates to:
+  /// **'Personal costs – or internal costs - are borne by the users themselves. These internal costs can be both tangible and intangible. In terms of mobility, these might be monetary costs for vehicles (purchase, operation, disposal or repurchase) or for a public transport ticket.'**
+  String get personal_description;
+
+  /// No description provided for @detail_social_description.
+  ///
+  /// In en, this message translates to:
+  /// **'The external costs are clustered into three categories: time, health, and environment. The time dimension includes congestion costs and time losses due to barrier effects (infrastructure can also act as a physical barrier, requiring detours, for example, in the case of railways, a level crossing must be used). The health dimension includes the costs caused by noise, accidents, and air pollution. The environment dimension includes costs due to climate damage and space consumption.'**
+  String get detail_social_description;
+
+  /// No description provided for @detail_social_time_description.
+  ///
+  /// In en, this message translates to:
+  /// **'The time dimension includes congestion costs and time losses due to barrier effects.'**
+  String get detail_social_time_description;
+
+  /// No description provided for @what_are_congestion_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'What are congestion costs?'**
+  String get what_are_congestion_costs;
+
+  /// No description provided for @detail_social_time_description_congestion.
+  ///
+  /// In en, this message translates to:
+  /// **'Congestion in road traffic or delays in public transport lead to time losses, which can be assessed in monetary terms with the help of willingness-to-pay approaches. Other negative effects of congestion are increased fuel consumption and wear and tear on roads and vehicles.\n\nThe total congestion costs for Munich (INRIX Traffic Scorecard) are allocated to individual modes of transport based on the space required and the vehicle kilometers traveled. In public transportation, average delays are used to calculate congestion costs.'**
+  String get detail_social_time_description_congestion;
+
+  /// No description provided for @what_are_barrier_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'What are costs due to barrier effects?'**
+  String get what_are_barrier_costs;
+
+  /// No description provided for @detail_social_time_description_barrier.
+  ///
+  /// In en, this message translates to:
+  /// **'Wide road and rail routes with high traffic loads lead to restrictions for other forms of mobility. For example, pedestrians and cyclists must take detours to cross the infrastructure barrier. In addition, the spatial separation of districts can result in reduced economic productivity.\n\nThe monetary costs of these barrier effects have been estimated in various studies. Corresponding cost rates per vehicle kilometer have been adopted for the online tool.'**
+  String get detail_social_time_description_barrier;
+
+  /// No description provided for @detail_social_health_description.
+  ///
+  /// In en, this message translates to:
+  /// **'The health dimension includes the costs caused by noise, accidents, and air pollution.'**
+  String get detail_social_health_description;
+
+  /// No description provided for @what_are_noise_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'What are noise costs?'**
+  String get what_are_noise_costs;
+
+  /// No description provided for @detail_social_health_description_noise.
+  ///
+  /// In en, this message translates to:
+  /// **'Noise from road and rail traffic causes disturbances and harms human health. This causes damage to society in the form of loss of value of real estate, reduced quality of life, as well as treatment costs and productivity losses due to physical, cognitive, or psychological impairments.\n\nThe amount of the noise costs is determined by the number of persons affected per level class, measured in dB(A). The total costs are then divided among the individual means of transport using weighting factors and mileage.'**
+  String get detail_social_health_description_noise;
+
+  /// No description provided for @what_are_accident_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'What are accident costs?'**
+  String get what_are_accident_costs;
+
+  /// No description provided for @detail_social_health_description_accidents.
+  ///
+  /// In en, this message translates to:
+  /// **'Traffic accidents cause medical costs, property damage, losses due to work absences, administrative expenses, and intangible costs (e.g., suffering and shock).\n\nOnly personal injury is included when calculating external costs, as property damage is largely covered by motor vehicle insurance and is therefore part of the personal costs.\nThe police accident statistics provide information on the accident’s severity, road users involved, and the causer.\n\nWith the help of appropriate cost rates, the total cost of each accident can be determined. The accident costs are allocated to the modes of transport according to the polluter pays principle (costs are allocated to the mode of transport causing the accident) and the damage potential principle (allocation is based on mass and speed).'**
+  String get detail_social_health_description_accidents;
+
+  /// No description provided for @what_are_air_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'What are costs due to air pollution'**
+  String get what_are_air_costs;
+
+  /// No description provided for @detail_social_health_description_air.
+  ///
+  /// In en, this message translates to:
+  /// **'Air pollution occurs both in vehicle operation through fuel combustion and abrasion and during fuel production. The consequences are material damage (e.g. to buildings), crop damage, biodiversity loss and damage to health (especially due to respiratory diseases).\n\nThe cost rates for various air pollutants, such as particulate matter, nitrogen oxides or ammonia, come from the Federal Environment Agency\'s Methodological Convention 3.1.\n'**
+  String get detail_social_health_description_air;
+
+  /// No description provided for @detail_social_environment_description.
+  ///
+  /// In en, this message translates to:
+  /// **'The environment dimension includes costs due to climate damage and space consumption.'**
+  String get detail_social_environment_description;
+
+  /// No description provided for @what_are_climate_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'What are costs due to climate damage?'**
+  String get what_are_climate_costs;
+
+  /// No description provided for @detail_social_environment_description_climate.
+  ///
+  /// In en, this message translates to:
+  /// **'Greenhouse gas emissions are generated during fuel combustion in the vehicle and during the production of fuels and energy. In the atmosphere, greenhouse gases lead to a change in the climate – with negative consequences for ecosystems, human health, and food production.\n\nThe Federal Environment Agency recommends the damage cost approach for determining climate damage. This involves estimating the damage caused by a given amount of greenhouse gases emitted. For this purpose, greenhouse gases such as carbon dioxide, methane, and nitrous oxide are converted into CO2 equivalents.'**
+  String get detail_social_environment_description_climate;
+
+  /// No description provided for @what_are_space_costs.
+  ///
+  /// In en, this message translates to:
+  /// **'What are costs due to space consumption?'**
+  String get what_are_space_costs;
+
+  /// No description provided for @detail_social_environment_description_space.
+  ///
+  /// In en, this message translates to:
+  /// **'Transportation needs space for driving and parking. The calculations in this online tool consider the city of Munich’s investments in road traffic, public transport, and bicycle traffic. In addition, so-called opportunity costs arise, as the space cannot be used for other purposes. In the case of cars, the costs for construction and maintenance of parking, as well as the income from parking fees, are also considered.'**
+  String get detail_social_environment_description_space;
+
+  /// No description provided for @detail_personal_description.
+  ///
+  /// In en, this message translates to:
+  /// **'These costs consist of fixed costs and variable costs. Fixed costs include costs such as vehicle depreciation. The variable costs are kilometre-dependent costs, such as fuel costs. The cost rates for bicycles and e-bikes include depreciation (fixed costs) as well as tyres, maintenance/repairs and electricity costs (variable costs). The fixed costs for the car include the subcategories depreciation, insurance, tax, MOT and parking. The variable costs include fuel costs, maintenance, repairs, tyres and care.'**
+  String get detail_personal_description;
+
+  /// No description provided for @detail_personal_fixed_description.
+  ///
+  /// In en, this message translates to:
+  /// **'Fixed costs include costs such as the depreciation of vehicles.'**
+  String get detail_personal_fixed_description;
+
+  /// No description provided for @detail_personal_variable_description.
+  ///
+  /// In en, this message translates to:
+  /// **'Variable costs are kilometer-dependent costs, such as fuel costs.'**
+  String get detail_personal_variable_description;
+
+  /// No description provided for @get_started.
+  ///
+  /// In en, this message translates to:
+  /// **'Start Full Cost Calculation'**
+  String get get_started;
+
+  /// No description provided for @diagram.
+  ///
+  /// In en, this message translates to:
+  /// **'Diagram'**
+  String get diagram;
+
+  /// No description provided for @about_us_title.
+  ///
+  /// In en, this message translates to:
+  /// **'About Us'**
+  String get about_us_title;
+
+  /// No description provided for @about_us_content.
+  ///
+  /// In en, this message translates to:
+  /// **'We are an interdisciplinary team consisting of five chairs from TU Munich and several external partners.\n\nOur goal is to transparently present and communicate the true costs of urban traffic in Munich.\n\nWe want to raise awareness of the costs of air pollutants, climate damage, accidents, congestion, land consumption, and noise caused by our mobility.\n\nWith this, we aim to promote sustainable and fair mobility behavior.'**
+  String get about_us_content;
+
+  /// No description provided for @research_content.
+  ///
+  /// In en, this message translates to:
+  /// **'The full cost calculator uses scientific methods to enable a cost comparison of different forms of mobility.'**
+  String get research_content;
+
+  /// No description provided for @note_address.
+  ///
+  /// In en, this message translates to:
+  /// **'*Please only enter addresses in Munich, otherwise not every route can be calculated.'**
+  String get note_address;
+
+  /// No description provided for @mode_of_transport.
+  ///
+  /// In en, this message translates to:
+  /// **'mode'**
+  String get mode_of_transport;
+
+  /// No description provided for @reload.
+  ///
+  /// In en, this message translates to:
+  /// **'Reload'**
+  String get reload;
+
+  /// No description provided for @error_empty.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter an address.'**
+  String get error_empty;
+
+  /// No description provided for @error_shorter_than_2.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter a longer address.'**
+  String get error_shorter_than_2;
+
+  /// No description provided for @copy_url.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy URL'**
+  String get copy_url;
+
+  /// No description provided for @url_copied.
+  ///
+  /// In en, this message translates to:
+  /// **'URL copied to clipboard'**
+  String get url_copied;
+
+  /// No description provided for @tell_a_friend.
+  ///
+  /// In en, this message translates to:
+  /// **'Do you like Mobi-Score? Tell a friend!'**
+  String get tell_a_friend;
+
+  /// No description provided for @field_empty_alert.
+  ///
+  /// In en, this message translates to:
+  /// **'The address field cannot be empty'**
+  String get field_empty_alert;
+
+  /// No description provided for @input_short_alert.
+  ///
+  /// In en, this message translates to:
+  /// **'Input must be longer than 2 characters'**
+  String get input_short_alert;
+
+  /// No description provided for @shared.
+  ///
+  /// In en, this message translates to:
+  /// **'Sharing'**
+  String get shared;
+
+  /// No description provided for @private.
+  ///
+  /// In en, this message translates to:
+  /// **'Private'**
+  String get private;
+
+  /// No description provided for @header_image_label.
+  ///
+  /// In en, this message translates to:
+  /// **'The title image shows an urban scene with multiple modes of transport: a teal bus, a cyclist on a teal bicycle, and an elevated white-and-orange train. People are walking in the background, and a large profile of a woman with dark hair is shown to the right, overlooking the city. The city has modern buildings, greenery, and statues.'**
+  String get header_image_label;
+
+  /// No description provided for @what_are.
+  ///
+  /// In en, this message translates to:
+  /// **'What are'**
+  String get what_are;
+
+  /// No description provided for @start_new_route.
+  ///
+  /// In en, this message translates to:
+  /// **'Start a new route'**
+  String get start_new_route;
+
+  /// No description provided for @mobi_score_description_1.
+  ///
+  /// In en, this message translates to:
+  /// **'In addition to private, internal costs (e.g. fuel costs or insurance), our individual mobility also causes external costs such as accident costs or noise costs. The Mobi-Score assesses precisely these external costs of our individual mobility. It is intended to raise awareness of the fact that the costs of our mobility are not distributed fairly - as there are costs that are not borne by the person who causes them, but by society as a whole.'**
+  String get mobi_score_description_1;
+
+  /// No description provided for @mobi_score_description_2.
+  ///
+  /// In en, this message translates to:
+  /// **'The Mobi-Score depends on the chosen mode of transport and the distance traveled. This can vary significantly between different modes of transport.'**
+  String get mobi_score_description_2;
+
+  /// No description provided for @mobi_score_description_3.
+  ///
+  /// In en, this message translates to:
+  /// **'If a route has comparatively high external costs, it receives the Mobi-Score E (red). On the other hand, if the route has low external costs, it receives the Mobi-Score A (green).'**
+  String get mobi_score_description_3;
+
+  /// No description provided for @imprint.
+  ///
+  /// In en, this message translates to:
+  /// **'Imprint'**
+  String get imprint;
+
+  /// No description provided for @imprint_content.
+  ///
+  /// In en, this message translates to:
+  /// **'Munich Cluster for the Future of Mobility in Metropolitan Regions (MCube)'**
+  String get imprint_content;
+
+  /// No description provided for @contact_details.
+  ///
+  /// In en, this message translates to:
+  /// **'Contact Details'**
+  String get contact_details;
+
+  /// No description provided for @contact.
+  ///
+  /// In en, this message translates to:
+  /// **'Publisher'**
+  String get contact;
+
+  /// No description provided for @imprint_contact_details_content.
+  ///
+  /// In en, this message translates to:
+  /// **'Technical University Munich\nTUM School of Engineering and Design\nChair of Urban Structure and Transport Planning\nArcisstraße 21\n80333 Munich'**
+  String get imprint_contact_details_content;
+
+  /// No description provided for @authorized_to_represent.
+  ///
+  /// In en, this message translates to:
+  /// **'Authorized to Represent'**
+  String get authorized_to_represent;
+
+  /// No description provided for @imprint_authorized_content.
+  ///
+  /// In en, this message translates to:
+  /// **'The Technical University of Munich is legally represented by the President, Prof. Dr. Thomas F. Hofmann.\nThe Technical University of Munich is, according to Art. 11 para. 1 sentence 1 BayHSchG, a public corporation with the right of self-administration within the framework of the laws and at the same time, according to Art. 1 para. 2 sentence 1 no. 1 BayHSchG, a state university (state institution). The Technical University of Munich handles its own matters as a corporation (corporate matters) under the legal supervision of the supervisory authority and state matters as a state institution (Art. 12 para. 1 BayHSchG).\nVAT DE811193231 (in accordance with § 27a of the Value Added Tax Act)'**
+  String get imprint_authorized_content;
+
+  /// No description provided for @responsible_for_content.
+  ///
+  /// In en, this message translates to:
+  /// **'Responsible for Content'**
+  String get responsible_for_content;
+
+  /// No description provided for @imprint_responsible_content.
+  ///
+  /// In en, this message translates to:
+  /// **'Julia Kinigadner\nE-Mail: sasim@mcube-cluster.com'**
+  String get imprint_responsible_content;
+
+  /// No description provided for @more_information.
+  ///
+  /// In en, this message translates to:
+  /// **'More information at:'**
+  String get more_information;
+
+  /// No description provided for @more_information_content.
+  ///
+  /// In en, this message translates to:
+  /// **'www.mcube-cluster.de\nhttps://www.mos.ed.tum.de/sv'**
+  String get more_information_content;
+
+  /// No description provided for @disclaimer.
+  ///
+  /// In en, this message translates to:
+  /// **'Disclaimer'**
+  String get disclaimer;
+
+  /// No description provided for @imprint_disclaimer_content.
+  ///
+  /// In en, this message translates to:
+  /// **'Despite careful content control, we assume no liability for the content of external links. The operators of the linked pages are solely responsible for their content. Articles marked by name in the discussion areas reflect the author\'s opinion. The authors are solely responsible for the content of their contributions.'**
+  String get imprint_disclaimer_content;
+
+  /// No description provided for @privacy_policy.
+  ///
+  /// In en, this message translates to:
+  /// **'Privacy Policy'**
+  String get privacy_policy;
+
+  /// No description provided for @general_information.
+  ///
+  /// In en, this message translates to:
+  /// **'General Information'**
+  String get general_information;
+
+  /// No description provided for @privacy_general_content.
+  ///
+  /// In en, this message translates to:
+  /// **'We take the protection of your personal data very seriously and treat your personal information confidentially and in accordance with legal data protection regulations as well as this privacy policy. This app does not require registration and does not store any personal data.'**
+  String get privacy_general_content;
+
+  /// No description provided for @responsible_person.
+  ///
+  /// In en, this message translates to:
+  /// **'Responsible Person'**
+  String get responsible_person;
+
+  /// No description provided for @privacy_responsible_content.
+  ///
+  /// In en, this message translates to:
+  /// **'The entity responsible for data processing in accordance with the General Data Protection Regulation (GDPR) is:\n\nMCube\nFreddie-Mercury-Straße 5\n80797 Munich\nPhone: +49 89 289-01\nE-Mail: sasim@mcube-cluster.com'**
+  String get privacy_responsible_content;
+
+  /// No description provided for @collection_and_processing_personal_data.
+  ///
+  /// In en, this message translates to:
+  /// **'Collection and Processing of Personal Data'**
+  String get collection_and_processing_personal_data;
+
+  /// No description provided for @privacy_collection_content.
+  ///
+  /// In en, this message translates to:
+  /// **'No personal data is stored or processed in the SASIM app. The use of the app does not require registration, and no user data that allows identification is stored.'**
+  String get privacy_collection_content;
+
+  /// No description provided for @processing_user_data.
+  ///
+  /// In en, this message translates to:
+  /// **'Processing of User Data'**
+  String get processing_user_data;
+
+  /// No description provided for @privacy_processing_content.
+  ///
+  /// In en, this message translates to:
+  /// **'The app only processes start and destination addresses entered by the user for routing purposes. These addresses are stored anonymously with a timestamp in log files, without any personal reference. This data is only used to provide the requested service and is not stored permanently.'**
+  String get privacy_processing_content;
+
+  /// No description provided for @third_party_services.
+  ///
+  /// In en, this message translates to:
+  /// **'Third-Party Services'**
+  String get third_party_services;
+
+  /// No description provided for @photon_header.
+  ///
+  /// In en, this message translates to:
+  /// **'Photon API'**
+  String get photon_header;
+
+  /// No description provided for @privacy_photon_content.
+  ///
+  /// In en, this message translates to:
+  /// **'For geocoding addresses, the Photon API is used, which is licensed under the **Apache License, Version 2.0**. For more information about Photon API and its licensing, please visit: https://photon.komoot.io/.'**
+  String get privacy_photon_content;
+
+  /// No description provided for @efa_header.
+  ///
+  /// In en, this message translates to:
+  /// **'EFA API of MVV'**
+  String get efa_header;
+
+  /// No description provided for @privacy_efa_content.
+  ///
+  /// In en, this message translates to:
+  /// **'For route planning and finding transportation options, we use the **EFA API** from the Munich Transport and Tariff Association (MVV). Through this API, information about public transport and sharing services from **ShareNow** and **Call a Bike** is provided. No personal data is stored or passed on to these providers.'**
+  String get privacy_efa_content;
+
+  /// No description provided for @data_security.
+  ///
+  /// In en, this message translates to:
+  /// **'Data Security'**
+  String get data_security;
+
+  /// No description provided for @privacy_security_content.
+  ///
+  /// In en, this message translates to:
+  /// **'We implement technical and organizational measures to ensure the security of the data processed by the app. As no personal data is stored, the risk of a data protection breach is minimal.'**
+  String get privacy_security_content;
+
+  /// No description provided for @cookies.
+  ///
+  /// In en, this message translates to:
+  /// **'Cookies'**
+  String get cookies;
+
+  /// No description provided for @privacy_cookies_content.
+  ///
+  /// In en, this message translates to:
+  /// **'This app does not use cookies or similar tracking technologies.'**
+  String get privacy_cookies_content;
+
+  /// No description provided for @your_rights.
+  ///
+  /// In en, this message translates to:
+  /// **'Your Rights'**
+  String get your_rights;
+
+  /// No description provided for @privacy_rights_content.
+  ///
+  /// In en, this message translates to:
+  /// **'Since no personal data is processed in this app, the rights of access, rectification, deletion, or restriction of processing according to Art. 15-18 GDPR are not applicable. If you still have questions regarding data protection in relation to the use of the app, you can contact us using the above contact information.'**
+  String get privacy_rights_content;
+
+  /// No description provided for @changes_to_privacy_policy.
+  ///
+  /// In en, this message translates to:
+  /// **'Changes to this Privacy Policy'**
+  String get changes_to_privacy_policy;
+
+  /// No description provided for @privacy_changes_content.
+  ///
+  /// In en, this message translates to:
+  /// **'We reserve the right to adjust this privacy policy to ensure it always complies with current legal requirements or to reflect changes to the app. Users will be informed of any changes in due time.'**
+  String get privacy_changes_content;
+
+  /// No description provided for @the_project.
+  ///
+  /// In en, this message translates to:
+  /// **'The Project'**
+  String get the_project;
+
+  /// No description provided for @the_project_content.
+  ///
+  /// In en, this message translates to:
+  /// **'This tool was developed as part of the SASIM research project, which is one of 14 projects in the first implementation phase of the Munich Cluster for the Future of Mobility in Metropolitan Regions (MCube). MCube is a future cluster funded by the BMBF, aiming to establish sustainable and transformative mobility innovations.\n\nOur goal is to make the true costs of urban transportation transparent and communicate them effectively. We aim to raise awareness about the costs of air pollutants, climate damage, accidents, traffic congestion, land use, and noise generated by our mobility. By doing so, we want to promote sustainable and fair mobility behavior.'**
+  String get the_project_content;
+
+  /// No description provided for @the_project_content_bold_1.
+  ///
+  /// In en, this message translates to:
+  /// **'SASIM'**
+  String get the_project_content_bold_1;
+
+  /// No description provided for @the_project_content_bold_2.
+  ///
+  /// In en, this message translates to:
+  /// **'MCube'**
+  String get the_project_content_bold_2;
+
+  /// No description provided for @the_project_content_bold_3.
+  ///
+  /// In en, this message translates to:
+  /// **'sustainable and transformative mobility innovations'**
+  String get the_project_content_bold_3;
+
+  /// No description provided for @the_project_content_bold_4.
+  ///
+  /// In en, this message translates to:
+  /// **'true costs of urban transportation'**
+  String get the_project_content_bold_4;
+
+  /// No description provided for @the_project_content_bold_5.
+  ///
+  /// In en, this message translates to:
+  /// **'air pollutants, climate damage, accidents, traffic congestion, land use, and noise'**
+  String get the_project_content_bold_5;
+
+  /// No description provided for @the_project_content_bold_6.
+  ///
+  /// In en, this message translates to:
+  /// **'sustainable and fair mobility behavior'**
+  String get the_project_content_bold_6;
+
+  /// No description provided for @the_web_app.
+  ///
+  /// In en, this message translates to:
+  /// **'The Web App'**
+  String get the_web_app;
+
+  /// No description provided for @the_web_app_content.
+  ///
+  /// In en, this message translates to:
+  /// **'The current status quo is that the costs caused by our mobility behavior are not fairly distributed. At the moment, we only pay for the private, internal costs of our mobility (e.g. fuel costs, ticket prices, or repair costs), but not the societal, external costs such as accident costs or noise costs. These are borne by society! Thus, those who cause high external costs through their mobility behavior are just as involved as those who cause low costs.\n\nThis freely available online tool evaluates individual route requests depending on the means of transportation. For now, the tool only calculates and evaluates routes within the city of Munich.'**
+  String get the_web_app_content;
+
+  /// No description provided for @the_web_app_content_bold_1.
+  ///
+  /// In en, this message translates to:
+  /// **'not fairly distributed'**
+  String get the_web_app_content_bold_1;
+
+  /// No description provided for @the_web_app_content_bold_2.
+  ///
+  /// In en, this message translates to:
+  /// **'not the societal, external costs'**
+  String get the_web_app_content_bold_2;
+
+  /// No description provided for @the_web_app_content_bold_3.
+  ///
+  /// In en, this message translates to:
+  /// **'This freely available online tool evaluates individual route requests depending on the means of transportation.'**
+  String get the_web_app_content_bold_3;
+
+  /// No description provided for @the_mobi_score.
+  ///
+  /// In en, this message translates to:
+  /// **'The Mobi-Score'**
+  String get the_mobi_score;
+
+  /// No description provided for @the_mobi_score_content.
+  ///
+  /// In en, this message translates to:
+  /// **'The evaluation in this tool takes into account the costs of air pollutants, climate damage, accidents, traffic congestion, land use, and noise. For each request, these costs are then illustrated for each selected mode of transport using the MobiScore.'**
+  String get the_mobi_score_content;
+
+  /// No description provided for @the_mobi_score_content_bold_1.
+  ///
+  /// In en, this message translates to:
+  /// **'air pollutants, climate damage, accidents, traffic congestion, land use, and noise'**
+  String get the_mobi_score_content_bold_1;
+
+  /// No description provided for @the_mobi_score_content_bullet_1.
+  ///
+  /// In en, this message translates to:
+  /// **'The MobiScore evaluates the true costs of our individual mobility and raises awareness of “invisible” costs.'**
+  String get the_mobi_score_content_bullet_1;
+
+  /// No description provided for @the_mobi_score_content_bullet_2.
+  ///
+  /// In en, this message translates to:
+  /// **'It provides an indication of how fair certain modes of transport are for any given route.'**
+  String get the_mobi_score_content_bullet_2;
+
+  /// No description provided for @the_team_behind.
+  ///
+  /// In en, this message translates to:
+  /// **'Who else is behind Mobi-Score?'**
+  String get the_team_behind;
+
+  /// No description provided for @the_team_behind_content.
+  ///
+  /// In en, this message translates to:
+  /// **'The Mobi-Score was developed as part of the SASIM research project by an interdisciplinary team of five chairs from the Technical University of Munich (TUM) and several external partners.'**
+  String get the_team_behind_content;
+
+  /// No description provided for @the_team_behind_content_hyperlink_1.
+  ///
+  /// In en, this message translates to:
+  /// **'SASIM research project'**
+  String get the_team_behind_content_hyperlink_1;
+
+  /// No description provided for @out_partners.
+  ///
+  /// In en, this message translates to:
+  /// **'Our Partners'**
+  String get out_partners;
+
+  /// No description provided for @personal_costs_research_content.
+  ///
+  /// In en, this message translates to:
+  /// **'The calculations of personal costs are largely based on the study by König et al. (2021). The full cost calculator uses the following cost rates (in euros per passenger-kilometer, unless otherwise stated):'**
+  String get personal_costs_research_content;
+
+  /// No description provided for @personal_costs_research_content_hyperlink_1.
+  ///
+  /// In en, this message translates to:
+  /// **'König et al. (2021)'**
+  String get personal_costs_research_content_hyperlink_1;
+
+  /// No description provided for @social_costs_research_content.
+  ///
+  /// In en, this message translates to:
+  /// **'The calculations of external costs are based on the study by Schröder et. al (2023). The full cost calculator uses the following cost rates (in cents per passenger-kilometer):'**
+  String get social_costs_research_content;
+
+  /// No description provided for @social_costs_research_content_hyperlink_1.
+  ///
+  /// In en, this message translates to:
+  /// **'Schröder et al. (2023)'**
+  String get social_costs_research_content_hyperlink_1;
+
+  /// No description provided for @routing_research.
+  ///
+  /// In en, this message translates to:
+  /// **'Routing'**
+  String get routing_research;
+
+  /// No description provided for @routing_research_content.
+  ///
+  /// In en, this message translates to:
+  /// **'The full cost calculator uses the software OpenTripPlanner (OTP) for route planning.\nBased on the inputs (start and destination address and selected travel mode), distance, travel time and the waypoints of the route are calculated.\n\nIn order to calculate routes and travel costs by public transportation, the timetable information system DEFAS is accessed via an API.'**
+  String get routing_research_content;
+
+  /// No description provided for @development_by.
+  ///
+  /// In en, this message translates to:
+  /// **'Frontent und Backend Development by'**
+  String get development_by;
+
+  /// No description provided for @illustrations_by.
+  ///
+  /// In en, this message translates to:
+  /// **'Illustrations by'**
+  String get illustrations_by;
+
+  /// No description provided for @ui_by.
+  ///
+  /// In en, this message translates to:
+  /// **'UI/UX Design by'**
+  String get ui_by;
+
+  /// No description provided for @routing_research_content_hyperlink_1.
+  ///
+  /// In en, this message translates to:
+  /// **'OpenTripPlanner (OTP)'**
+  String get routing_research_content_hyperlink_1;
+
+  /// No description provided for @routing_research_content_hyperlink_2.
+  ///
+  /// In en, this message translates to:
+  /// **'DEFAS'**
+  String get routing_research_content_hyperlink_2;
+
+  /// No description provided for @want_to_help_us.
+  ///
+  /// In en, this message translates to:
+  /// **'Want to help us improve?'**
+  String get want_to_help_us;
+
+  /// No description provided for @want_to_help_us_explanation.
+  ///
+  /// In en, this message translates to:
+  /// **'Click on the button below or scan the QR code to participate in our survey. Your feedback is important to us!'**
+  String get want_to_help_us_explanation;
+
+  /// No description provided for @to_the_survey.
+  ///
+  /// In en, this message translates to:
+  /// **'To the survey'**
+  String get to_the_survey;
+
+  /// No description provided for @mode_not_available.
+  ///
+  /// In en, this message translates to:
+  /// **'This mode of transportation is not available for this route.'**
+  String get mode_not_available;
+
+  /// No description provided for @x_not_available.
+  ///
+  /// In en, this message translates to:
+  /// **' is not available for this route.'**
+  String get x_not_available;
+
+  /// No description provided for @try_another_route.
+  ///
+  /// In en, this message translates to:
+  /// **'If you still want to compare the true costs of this mode of transportation, please choose another route'**
+  String get try_another_route;
+
+  /// No description provided for @resume.
+  ///
+  /// In en, this message translates to:
+  /// **'Weiter'**
+  String get resume;
+
+  /// No description provided for @address_not_found_text.
+  ///
+  /// In en, this message translates to:
+  /// **'This address could not be found. Is it located in Munich? Try again with a different one!'**
+  String get address_not_found_text;
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) => <String>['de', 'en'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+AppLocalizations lookupAppLocalizations(Locale locale) {
+
+
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'de': return AppLocalizationsDe();
+    case 'en': return AppLocalizationsEn();
+  }
+
+  throw FlutterError(
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.'
+  );
+}

--- a/flutter_frontend/multimodal_routeplanner/lib/l10n/app_localizations_de.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/l10n/app_localizations_de.dart
@@ -1,0 +1,694 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for German (`de`).
+class AppLocalizationsDe extends AppLocalizations {
+  AppLocalizationsDe([String locale = 'de']) : super(locale);
+
+  @override
+  String get that_are_the_true_costs_header => 'Das sind die wahren Kosten der Mobilität';
+
+  @override
+  String get these_are_external_costs => 'Das sind die externen Kosten deiner Route';
+
+  @override
+  String get what_is_mobi_score => 'Was ist der Mobi-Score?';
+
+  @override
+  String get calculator => 'Rechner';
+
+  @override
+  String get information => 'Informationen';
+
+  @override
+  String get about_us => 'Über uns';
+
+  @override
+  String get start_address => 'Startadresse';
+
+  @override
+  String get end_address => 'Zieladresse';
+
+  @override
+  String get please_insert_address => 'Bitte gib eine Adresse an';
+
+  @override
+  String get from => 'Von';
+
+  @override
+  String get from_hint => 'Von (z.B. Arcisstraße 21, München)';
+
+  @override
+  String get to => 'Nach';
+
+  @override
+  String get to_hint => 'Nach (z.B. Ostbahnhof, München)';
+
+  @override
+  String get new_route => 'Neue Route';
+
+  @override
+  String get show_route => 'Route anzeigen';
+
+  @override
+  String get car => 'Pkw';
+
+  @override
+  String get ecar => 'E-Pkw';
+
+  @override
+  String get bike => 'Fahrrad';
+
+  @override
+  String get ebike => 'E-Fahrrad';
+
+  @override
+  String get moped => 'Moped';
+
+  @override
+  String get e_moped => 'E-Moped';
+
+  @override
+  String get tier => 'TIER E-Scooter';
+
+  @override
+  String get cab => 'Call a Bike';
+
+  @override
+  String get flinkster => 'Flinkster';
+
+  @override
+  String get emmy => 'Emmy';
+
+  @override
+  String get sharenow => 'Sharenow';
+
+  @override
+  String get pt => 'ÖPNV';
+
+  @override
+  String get metro => 'U-Bahn';
+
+  @override
+  String get tram => 'Tram';
+
+  @override
+  String get bus => 'Bus';
+
+  @override
+  String get e_bus => 'E-Bus';
+
+  @override
+  String get pt_and_bike => 'ÖPNV + Fahrrad';
+
+  @override
+  String get walk => 'Zu Fuß';
+
+  @override
+  String get not_available => 'Nicht verfügbar';
+
+  @override
+  String get description_fullcosts => 'Die Gesamtkosten, die bei der Nutzung eines Verkehrsmittels entstehen, einschließlich direkter und indirekter Kosten wie Treibstoff, Wartung, Versicherung und Umweltauswirkungen.';
+
+  @override
+  String get description_external_costs => 'Kosten, die durch die Nutzung eines Verkehrsmittels entstehen, aber nicht direkt von den Benutzern getragen werden. Dazu gehören Umweltschäden, Gesundheitsprobleme und soziale Kosten.';
+
+  @override
+  String get description_internal_costs => 'Die direkten Kosten, die von den Benutzern eines Verkehrsmittels getragen werden, wie Treibstoffkosten, Wartung und Versicherung.';
+
+  @override
+  String get descripton_accidents => 'Unfallkosten sind die Kosten, die durch bei Unfällen entstehende Personenschäden entstehen. da Sachschäden an Autos und Infrastruktur überwiegend von der Kfz-Versicherung abgedeckt oder von den Parteien, die den Schaden verursacht haben, selbst getragen werden, werden sie hier nicht berücksichtigt.';
+
+  @override
+  String get description_air => 'Die Berechnung der Kosten durch Luftverschmutzung umfasst verschiedene Aspekte. Dazu gehören Sachschäden, Ernteausfälle, Verlust der Biodiversität und Gesundheitsschäden, die durch Luftverschmutzung entstehen.';
+
+  @override
+  String get description_noise => 'Die Auswirkungen von Lärm sind in verschiedenen Lebensbereichen spürbar. So verursacht Verkehrslärm Kosten für eine Volkswirtschaft in vielerlei Hinsicht.';
+
+  @override
+  String get description_space => 'Der Verkehr nutzt Land in zwei verschiedenen Verkehrssituationen. Land wird für die Bewegung von Verkehr über Straßen oder Schienensysteme genutzt. Gleichzeitig beanspruchen Fahrzeuge, die nicht in Bewegung sind, Platz für das Parken.';
+
+  @override
+  String get description_congestion => 'Staus sind hauptsächlich als blockierte Straßen durch Autos und andere Straßennutzer bekannt. Es gibt jedoch auch viele überlastete öffentliche Verkehrsnetze, die zu Verzögerungen führen. In beiden Fällen geht Zeit verloren, und somit entstehen Kosten.';
+
+  @override
+  String get description_barrier => 'Die Zerschneidung beschreibt die Zeitverzögerung, die der motorisierte Verkehr auf aktive Formen der Mobilität ausübt. Dies kann in Form von großen Straßen sein, die Fußgänger überqueren oder umgehen müssen, um ihr Ziel zu erreichen.';
+
+  @override
+  String get description_environment => 'Kosten durch Umweltschäden beschreiben Kosten durch alle Schäden, die heute und in der Zukunft durch den Klimawandel verursacht werden, und die mit Unsicherheiten verbunden sind. Sie sind abhängig vom Antriebstyp des Fahrzeugs und beinhaltet Kosten aus dem Betrieb des Fahrzeugs sowie der Herstellung von Kraftstoff und Energie';
+
+  @override
+  String get external_costs => 'Externe Kosten';
+
+  @override
+  String get internal_costs => 'Interne Kosten';
+
+  @override
+  String get fullcosts => 'Vollkosten';
+
+  @override
+  String get accidents => 'Unfälle';
+
+  @override
+  String get air_pollution => 'Luftverschmutzung';
+
+  @override
+  String get noise => 'Lärm';
+
+  @override
+  String get space_use => 'Flächenverbrauch';
+
+  @override
+  String get congestion => 'Stau';
+
+  @override
+  String get barrier_effects => 'Zerschneidung';
+
+  @override
+  String get environmental_damages => 'Umweltschäden';
+
+  @override
+  String get mobi_score => 'Mobi-Score';
+
+  @override
+  String get header_external_costs => 'externe\nKosten';
+
+  @override
+  String get header_internal_costs => 'interne\nKosten';
+
+  @override
+  String get header_fullcosts => 'Voll\nkosten';
+
+  @override
+  String get header_mobi_score => 'Mobi-\nScore';
+
+  @override
+  String get something_went_wrong => '...Irgendwas ist schiefgegangen';
+
+  @override
+  String get please_try_again => 'Bitte lade die Seite neu oder wähle eine andere Route.';
+
+  @override
+  String get try_again => 'Versuche es erneut';
+
+  @override
+  String get research => 'Forschung';
+
+  @override
+  String get by => 'von';
+
+  @override
+  String get de => 'de';
+
+  @override
+  String get en => 'en';
+
+  @override
+  String get electric => 'Elektrisch';
+
+  @override
+  String get calculate => 'Berechnen';
+
+  @override
+  String get error => 'Error';
+
+  @override
+  String get show_detailed_info => 'Detailierte Routeninformationen';
+
+  @override
+  String get these_are_the_costs_of_your_journey_with => 'Das sind die wahren Kosten deiner Fahrt mit';
+
+  @override
+  String get private_car => 'einem privaten Auto';
+
+  @override
+  String get private_ecar => 'einem privaten E-Auto';
+
+  @override
+  String get shared_car => 'Car-Sharing';
+
+  @override
+  String get private_bike => 'einem privaten Fahrrad';
+
+  @override
+  String get private_ebike => 'einem privaten E-Bike';
+
+  @override
+  String get shared_bike => 'Bike-Sharing';
+
+  @override
+  String get public_transport => 'den Öffis';
+
+  @override
+  String get unknown => 'Unbekannt';
+
+  @override
+  String get fullcosts_of_trip => 'Vollkosten der Fahrt';
+
+  @override
+  String get social_costs => 'externe Kosten';
+
+  @override
+  String get social_costs_two_line => 'externe\nKosten';
+
+  @override
+  String get personal_costs => 'persönliche Kosten';
+
+  @override
+  String get personal_costs_two_line => 'persönliche\nKosten';
+
+  @override
+  String get back_to_results => 'Zurück';
+
+  @override
+  String get share => 'Teilen oder gib uns etwas Feedback';
+
+  @override
+  String get time => 'Zeit';
+
+  @override
+  String get health => 'Gesundheit';
+
+  @override
+  String get environment => 'Umwelt';
+
+  @override
+  String get fixed => 'Fix';
+
+  @override
+  String get variable => 'Variabel';
+
+  @override
+  String get route_is_loading => 'Routen werden geladen...';
+
+  @override
+  String get learn_about => 'Erfahre die wahren Kosten Deiner Mobilität';
+
+  @override
+  String get input_instructions => 'Wähle ein Verkehrsmittel aus und gib Start und Ziel Deines Weges in München ein, um die wahren Kosten zu berechnen.';
+
+  @override
+  String get total_costs => 'Vollkosten';
+
+  @override
+  String get total => 'Vollkosten';
+
+  @override
+  String get social => 'extern';
+
+  @override
+  String get overall => 'gesamt';
+
+  @override
+  String get personal => 'persönlich';
+
+  @override
+  String get time_costs => 'zeitlbezogene Kosten';
+
+  @override
+  String get health_costs => 'gesundheitsbezogene Kosten';
+
+  @override
+  String get environment_costs => 'umweltbezogene Kosten';
+
+  @override
+  String get fixed_costs => 'Fixkosten';
+
+  @override
+  String get variable_costs => 'variable Kosten';
+
+  @override
+  String get by_mode => 'nach Verkehrsmittel';
+
+  @override
+  String get total_description => 'Die wahren Kosten - oder Vollkosten - der Mobilität sind die Summe der persönlichen und externen Kosten. Die externen Kosten werden nicht vom Verursacher, sondern von der Allgemeinheit getragen.';
+
+  @override
+  String get social_description => 'Externalitäten entstehen immer dann, wenn die Aktivitäten einer Person oder eines Unternehmens Auswirkungen auf unbeteiligte haben, die nicht im Preis enthalten sind. Diese Auswirkungen können positive (externe Nutzen) als auch negative (externe Kosten) sein.\nBezogen auf Mobilität bedeuten externe Kosten also, dass die Kosten von Verkehrsaktivitäten nicht von den Reisenden selbst getragen werden, sondern von der Allgemeinheit.';
+
+  @override
+  String get personal_description => 'Persönliche Kosten werden von den Verursacherinnen und Verursachern einer Aktivität selbst getragen. Diese internen Kosten können sowohl materiell als auch immateriell sein. Bezogen auf Mobilität kann es sich beispielsweise um materielle Kosten für Fahrzeuge (Anschaffung, Betrieb, Entsorgung bzw. Wiederkauf) oder für einen Fahrschein im Öffentlichen Verkehr handeln.';
+
+  @override
+  String get detail_social_description => 'Die externen Kosten werden in drei Kategorien eingeteilt: Zeit, Gesundheit und Umwelt. Die Zeitdimension umfasst Staukosten und Zeitverluste durch Zerschneidung (eine Infrastruktur kann auch eine räumliche Barriere sein, wodurch Umwege genommen werden müssen, z.B. bei Schienen muss ein Bahnübergang gewählt werden). Die gesundheitliche Dimension umfasst die Kosten, die durch Lärm, Unfälle und Luftverschmutzung verursacht werden. Die Umweltdimension umfasst Kosten durch Klimaschäden und Flächeninanspruchnahme.';
+
+  @override
+  String get detail_social_time_description => 'Die Zeitdimension umfasst Staukosten und Zeitverluste durch Zerschneidung.';
+
+  @override
+  String get what_are_congestion_costs => 'Was sind Staukosten?';
+
+  @override
+  String get detail_social_time_description_congestion => 'Staus im Straßenverkehr oder auch Verspätungen im öffentlichen Verkehr führen zu Zeitverlusten, die mithilfe von Zahlungsbereitschaften monetär bewertet werden können. Weitere negative Auswirkungen von Stau sind erhöhter Treibstoffverbrauch sowie Verschleiß von Straßen und Fahrzeugen.\n\nZur Berechnung der Staukosten im Straßenverkehr werden die gesamten Staukosten für München (INRIX Traffic Scorecard) anhand des Flächenbedarfs und der zurückgelegten Fahrzeugkilometer auf die einzelnen Verkehrsmittel aufgeteilt. Im Öffentlichen Verkehr wird mit durchschnittlichen Verspätungswerten gerechnet.';
+
+  @override
+  String get what_are_barrier_costs => 'Was sind Kosten durch Zerschneidung?';
+
+  @override
+  String get detail_social_time_description_barrier => 'Insbesondere breite Straßen- und Schienenwege mit hoher Verkehrsbelastung führen zu Einschränkungen für andere Mobilitätsformen. Beispielsweise müssen Zufußgehende und Fahrradfahrende Umwege in Kauf nehmen, um die Infrastrukturbarriere zu überwinden. Außerdem kann die Abgrenzung von Stadtteilen eine verringerte wirtschaftliche Produktivität zur Folge haben.\n\nDie monetären Kosten dieser Trennwirkungen wurden im Rahmen verschiedener Studien abgeschätzt. Entsprechende Kostensätze je Fahrzeugkilometer wurden für das vorliegende Online-Tool übernommen.';
+
+  @override
+  String get detail_social_health_description => 'Die gesundheitliche Dimension umfasst die Kosten, die durch Lärm, Unfälle und Luftverschmutzung verursacht werden.';
+
+  @override
+  String get what_are_noise_costs => 'Was sind Lärmkosten?';
+
+  @override
+  String get detail_social_health_description_noise => 'Lärm durch Straßen- und Schienenverkehr verursacht Belästigungen und hat negative Auswirkungen auf die menschliche Gesundheit. Der Gesellschaft entstehen dadurch Schäden in Form von Wertverlust bei Immobilien, verminderter Lebensqualität sowie Behandlungskosten und Produktivitätsverlusten infolge physischer, kognitiver oder psychologischer Beeinträchtigungen.\n\nDie Höhe der Lärmkosten wird über die Anzahl der betroffenen Personen je Pegelklasse, gemessen in dB(A), bestimmt. Die Gesamtkosten werden anschließend mithilfe von Gewichtungsfaktoren und Fahrleistungen auf die einzelnen Verkehrsmittel aufgeteilt.';
+
+  @override
+  String get what_are_accident_costs => 'Was sind Unfallkosten?';
+
+  @override
+  String get detail_social_health_description_accidents => 'Verkehrsunfälle verursachen medizinische Heilungskosten, Sachschäden, Verluste durch Arbeitsausfall, administrative Aufwände sowie immaterielle Kosten (z. B. Leid und Schock).\n\nNur Personenschäden fließen in die Berechnung der externen Kosten mit ein, da Sachschäden weitestgehend über die Kfz-Haftpflichtversicherungen abgedeckt sind und somit zu den persönlichen Kosten zählen.\n\nDie polizeiliche Unfallstatistik liefert Informationen zu Unfallschwere, beteiligten Verkehrsteilnehmenden und Verursacher. Mithilfe von entsprechenden Kostensätzen lassen sich die Gesamtkosten jedes Unfalls ermittelt. Die Aufteilung der Unfallkosten auf die betroffenen Verkehrsmittel erfolgt durch das Verursacherprinzip (Kosten werden dem verursachenden Verkehrsmittel angelastet) und das Schadenspotenzialprinzip (Aufteilung erfolgt nach Masse und Geschwindigkeit).';
+
+  @override
+  String get what_are_air_costs => 'Was sind Kosten durch Luftverschmutzung?';
+
+  @override
+  String get detail_social_health_description_air => 'Luftverschmutzung entsteht sowohl im Fahrzeugbetrieb durch Kraftstoffverbrennung und Abrieb als auch bei der Kraftstoffherstellung. Die Folgen sind Materialschäden (z. B. an Gebäuden), Ernteschäden, Biodiversitätsverluste und Gesundheitsschäden (insbesondere durch Atemwegserkrankungen).\n\nDie Kostensätze für verschiedene Luftschadstoffe, beispielsweise Feinstaub, Stickoxide oder Ammoniak, stammen aus der Methodenkonvention 3.1 des Umweltbundesamtes.';
+
+  @override
+  String get detail_social_environment_description => 'Die Umweltdimension umfasst Kosten durch Klimaschäden und Flächenverbrauch.';
+
+  @override
+  String get what_are_climate_costs => 'Was sind Kosten durch Klimaschäden?';
+
+  @override
+  String get detail_social_environment_description_climate => 'Treibhausgasemissionen entstehen bei der Kraftstoffverbrennung im Fahrzeug, aber auch bei der Produktion von Kraftstoffen und Energie. In der Atmosphäre führen Treibhausgase zu einer Veränderung des Klimas – mit negativen Folgen für Ökosysteme, die menschliche Gesundheit und die Nahrungsmittelproduktion. \n\nDas Umweltbundesamt empfiehlt für die Bestimmung von Klimaschäden den Schadenskostenansatz. Dabei wird die Höhe der Schäden geschätzt, die durch eine bestimmte Menge an emittierten Treibhausgasen verursacht werden. Treibhausgase wie Kohlenstoffdioxid, Methan und Lachgas werden dazu in CO2-Äquivalente umgerechnet.';
+
+  @override
+  String get what_are_space_costs => 'Was sind Kosten durch Flächenverbrauch?';
+
+  @override
+  String get detail_social_environment_description_space => 'Verkehr benötigt Fläche zum Fahren und Parken. Die Berechnungen im vorliegenden Online-Tool berücksichtigen die Investitionen der Stadt München für den Straßenverkehr, Öffentlichen Verkehr und Fahrradverkehr. Außerdem entstehen sogenannte Opportunitätskosten, da die Fläche nicht anderweitig genutzt werden kann. Beim Pkw werden zusätzlich die Kosten für Bau und Unterhaltung von Parkplätzen sowie die Einnahmen aus Parkgebühren berücksichtigt.';
+
+  @override
+  String get detail_personal_description => 'Diese Kosten bestehen aus Fixkosten und variablen Kosten. Zu den Fixkosten gehören Kosten wie z.B. Wertverlust von Fahrzeugen. Bei den variablen Kosten handelt es sich um kilometerabhängige Kosten, wie z. B. Kraftstoffkosten.\nDie Kostensätze für Fahrrad und E-Fahrrad beinhalten den Wertverlust (Fixkosten) sowie Reifen, Wartung / Reparatur und Stromkosten (variable Kosten). Die Fixkosten für den PKW beinhalten Wertverlust, Versicherung, Steuer, TÜV und Parken. Die variablen Kosten enthalten Kraftstoffkosten, Wartung, Reparatur, Reifen und Pflege.';
+
+  @override
+  String get detail_personal_fixed_description => 'Zu den Fixkosten gehören Kosten wie der Wertverlust von Fahrzeugen.';
+
+  @override
+  String get detail_personal_variable_description => 'Variable Kosten sind kilometerabhängige Kosten, wie z. B. Kraftstoffkosten.';
+
+  @override
+  String get get_started => 'zum Vollkostenrechner';
+
+  @override
+  String get diagram => 'Diagramm';
+
+  @override
+  String get about_us_title => 'Wer wir sind';
+
+  @override
+  String get about_us_content => 'Wir sind ein interdisziplinäres Team bestehend aus fünf Lehrstühlen der TU München und mehreren externen Partnern.\n\nUnser Ziel ist es, die wahren Kosten des urbanen Verkehrs in München transparent darzustellen und zu kommunizieren.\n\nWir möchten Bewusstsein für die Kosten von Luftschadstoffen, Klimaschäden, Unfällen, Stau, Flächenverbrauch, Zerschnidung und Lärm schaffen, die unsere Mobilität hervorruft.\n\nDamit wollen wir nachhaltiges und gerechtes Mobilitätsverhalten fördern.';
+
+  @override
+  String get research_content => 'Der Vollkostenrechner nutzt wissenschaftliche Methoden, um einen Kostenvergleich verschiedener Mobilitätsformen zu ermöglichen.';
+
+  @override
+  String get note_address => '*Bitte gib nur Adressen in München ein, da sonst nicht jede Route berechnet werden kann.';
+
+  @override
+  String get mode_of_transport => 'Verkehrsmittel';
+
+  @override
+  String get reload => 'Neu laden';
+
+  @override
+  String get error_empty => 'Gib eine Adresse ein.';
+
+  @override
+  String get error_shorter_than_2 => 'Gib eine längere Adresse ein.';
+
+  @override
+  String get copy_url => 'URL kopieren';
+
+  @override
+  String get url_copied => 'URL in die Zwischenablage kopiert';
+
+  @override
+  String get tell_a_friend => 'Gefällt dir Mobi-Score? Erzähle es einem Freund!';
+
+  @override
+  String get field_empty_alert => 'Das Addressfeld darf nicht leer sein.';
+
+  @override
+  String get input_short_alert => 'Bitte gib eine längere Adresse ein.';
+
+  @override
+  String get shared => 'Sharing';
+
+  @override
+  String get private => 'Privat';
+
+  @override
+  String get header_image_label => 'Das Titelbild zeigt eine urbane Szene mit mehreren Verkehrsmitteln: einem türkisfarbenen Bus, einer Radfahrerin auf einem türkisfarbenen Fahrrad und einer erhöhten weiß-orangefarbenen Bahn. Im Hintergrund gehen Menschen spazieren, und rechts ist ein großes Profil einer Frau mit dunklen Haaren zu sehen, die über die Stadt blickt. Die Stadt hat moderne Gebäude, Grünflächen und Statuen.';
+
+  @override
+  String get what_are => 'Was sind';
+
+  @override
+  String get start_new_route => 'Neue Route starten';
+
+  @override
+  String get mobi_score_description_1 => 'Unsere individuelle Mobilität verursacht neben den privaten, internen Kosten (z.B. Spritkosten oder Versicherungen) auch externe Kosten wie Unfallkosten oder Lärmkosten. Der Mobi-Score bewertet gerade diese externen Kosten unserer individuellen Mobilität. Er soll Bewusstsein dafür schaffen, dass die Kosten unserer Mobilität nicht gerecht verteilt sind – da es Kosten gibt, die nicht der Verursacher selbst trägt, sondern die Gesellschaft als Ganzes.';
+
+  @override
+  String get mobi_score_description_2 => 'Der Mobi-Score hängt von dem gewählten Verkehrsmittel sowie der zurückgelegten Distanz ab. Diese kann bei verschiedenen Verkehrsmitteln zum Teil stark variieren.';
+
+  @override
+  String get mobi_score_description_3 => 'Weist ein Weg vergleichsweise hohe externe Kosten auf, so erhält dieser den Mobi-Score E (rot). Weist der Weg hingegen niedrige externe Kosten auf, so erhält er den Mobi-Score A (grün).';
+
+  @override
+  String get imprint => 'Impressum';
+
+  @override
+  String get imprint_content => 'Münchner Cluster für die Zukunft der Mobilität in Metropolregionen (MCube)';
+
+  @override
+  String get contact_details => 'Herausgeberin';
+
+  @override
+  String get contact => 'Kontakt';
+
+  @override
+  String get imprint_contact_details_content => 'Technische Universität München\nTUM School of Engineering and Design\nLehrstuhl für Siedlungsstruktur und Verkehrsplanung\nArcisstraße 21\n80333 München';
+
+  @override
+  String get authorized_to_represent => 'Vertretungsberechtigt';
+
+  @override
+  String get imprint_authorized_content => 'Die Technische Universität München wird gesetzlich vertreten durch den Präsidenten Prof. Dr. Thomas F. Hofmann.\nDie Technische Universität München ist gemäß Art. 11 Abs. 1 S. 1 BayHSchG eine Körperschaft des öffentlichen Rechts mit dem Recht der Selbstverwaltung im Rahmen der Gesetze und zugleich gemäß Art. 1 Abs. 2 Satz 1 Nr. 1 BayHSchG staatliche Hochschule (staatliche Einrichtung). Die Technische Universität München nimmt eigene Angelegenheiten als Körperschaft (Körperschaftsangelegenheiten) unter der Rechtsaufsicht der Aufsichtsbehörde, staatliche Angelegenheiten als staatliche Einrichtung wahr (Art. 12 Abs. 1 BayHSchG).\nUmsatzsteueridentifikationsnummer DE811193231 (gemäß § 27a Umsatzsteuergesetz)';
+
+  @override
+  String get responsible_for_content => 'Inhaltlich verantwortlich';
+
+  @override
+  String get imprint_responsible_content => 'Julia Kinigadner\nE-Mail: sasim@mcube-cluster.com';
+
+  @override
+  String get more_information => 'Mehr Informationen unter:';
+
+  @override
+  String get more_information_content => 'www.mcube-cluster.de\nhttps://www.mos.ed.tum.de/sv';
+
+  @override
+  String get disclaimer => 'Haftungshinweis';
+
+  @override
+  String get imprint_disclaimer_content => 'Trotz sorgfältiger inhaltlicher Kontrolle übernehmen wir keine Haftung für die Inhalte externer Links. Für den Inhalt der verlinkten Seiten sind ausschließlich deren Betreiber verantwortlich. Namentlich gekennzeichnete Beiträge in den Diskussionsbereichen geben die Meinung des Autors wieder. Für die Inhalte der Beiträge sind ausschließlich die Autoren zuständig.';
+
+  @override
+  String get privacy_policy => 'Datenschutzerklärung';
+
+  @override
+  String get general_information => 'Allgemeine Hinweise';
+
+  @override
+  String get privacy_general_content => 'Wir nehmen den Schutz Ihrer persönlichen Daten sehr ernst und behandeln Ihre personenbezogenen Daten vertraulich und entsprechend den gesetzlichen Datenschutzvorschriften sowie dieser Datenschutzerklärung. Diese App erfordert keine Anmeldung und speichert keine personenbezogenen Daten.';
+
+  @override
+  String get responsible_person => 'Verantwortlicher';
+
+  @override
+  String get privacy_responsible_content => 'Verantwortlich für die Datenverarbeitung im Sinne der Datenschutz-Grundverordnung (DSGVO) ist:\n\nMCube\nFreddie-Mercury-Straße 5\n80797 München\nTelefon: +49 89 289-01\nE-Mail: sasim@mcube-cluster.com';
+
+  @override
+  String get collection_and_processing_personal_data => 'Erhebung und Verarbeitung personenbezogener Daten';
+
+  @override
+  String get privacy_collection_content => 'In der SASIM App werden keine personenbezogenen Daten gespeichert oder verarbeitet. Die Nutzung der App erfordert keine Registrierung und es erfolgt keine Speicherung von Nutzerdaten, die eine Identifizierung ermöglichen.';
+
+  @override
+  String get processing_user_data => 'Verarbeitung von Nutzungsdaten';
+
+  @override
+  String get privacy_processing_content => 'Die App verarbeitet lediglich Start- und Zieladressen, die der Nutzer für Routingzwecke eingibt. Diese Adressen werden ohne Personenbezug und ausschließlich mit einem Zeitstempel in anonymen Logfiles gespeichert. Diese Daten dienen ausschließlich zur Erbringung der angeforderten Dienstleistung und werden nicht dauerhaft gespeichert.';
+
+  @override
+  String get third_party_services => 'Drittanbieterdienste';
+
+  @override
+  String get photon_header => 'Photon API';
+
+  @override
+  String get privacy_photon_content => 'Für die Geocodierung von Adressen wird die Photon API verwendet, die unter der Apache License, Version 2.0 lizenziert ist. Weitere Informationen zur Photon API und zur Lizenzierung finden Sie unter: https://photon.komoot.io/.';
+
+  @override
+  String get efa_header => 'EFA API der MVV';
+
+  @override
+  String get privacy_efa_content => 'Für die Routenplanung und das Auffinden von Verkehrsmitteln verwenden wir die EFA API des Münchner Verkehrs- und Tarifverbundes (MVV). Über diese API werden Informationen zu öffentlichen Verkehrsmitteln sowie zu Sharing-Angeboten von ShareNow und Call a Bike bereitgestellt. Hierbei erfolgt keine Speicherung oder Weitergabe personenbezogener Daten an diese Anbieter.';
+
+  @override
+  String get data_security => 'Datensicherheit';
+
+  @override
+  String get privacy_security_content => 'Wir setzen technische und organisatorische Maßnahmen ein, um die Sicherheit der durch die App verarbeiteten Daten zu gewährleisten. Da keine personenbezogenen Daten gespeichert werden, ist das Risiko eines Datenschutzverstoßes minimal.';
+
+  @override
+  String get cookies => 'Cookies';
+
+  @override
+  String get privacy_cookies_content => 'Diese App verwendet keine Cookies oder ähnliche Tracking-Technologien.';
+
+  @override
+  String get your_rights => 'Ihre Rechte';
+
+  @override
+  String get privacy_rights_content => 'Da in dieser App keine personenbezogenen Daten verarbeitet werden, sind die Rechte auf Auskunft, Berichtigung, Löschung oder Einschränkung der Verarbeitung gemäß Art. 15-18 DSGVO nicht anwendbar. Sollten Sie dennoch Fragen zum Datenschutz in Bezug auf die Nutzung der App haben, können Sie uns unter den oben angegebenen Kontaktdaten erreichen.';
+
+  @override
+  String get changes_to_privacy_policy => 'Änderungen dieser Datenschutzerklärung';
+
+  @override
+  String get privacy_changes_content => 'Wir behalten uns das Recht vor, diese Datenschutzerklärung anzupassen, um sie stets den aktuellen rechtlichen Anforderungen anzupassen oder Änderungen in der App umzusetzen. Über Änderungen werden wir die Nutzer rechtzeitig informieren.';
+
+  @override
+  String get the_project => 'Das Projekt';
+
+  @override
+  String get the_project_content => 'Der Mobi-Score wurde im Rahmen des Forschungsprojekts SASIM von einem interdisziplinären Team aus fünf Lehrstühlen der Technischen Universität München (TUM) und mehreren externen Partnern entwickelt. SASIM ist eines von 14 Projekten der ersten Umsetzungsphase der Münchner Cluster für die Zukunft der Mobilität in Metropolregionen (MCube). MCube ist ein durch das BMBF gefördertes Zukunftscluster, das sich zum Ziel gesetzt hat, nachhaltige und transformative Mobilitätsinnovationen zu etablieren.\n\nUnser Ziel ist es, die wahren Kosten des urbanen Verkehrs transparent darzustellen und zu kommunizieren. Wir möchten Bewusstsein für die Kosten von Luftschadstoffen, Klimaschäden, Unfälle, Stau, Flächenverbrauch, Zerschneidung und Lärm schaffen, die unsere Mobilität hervorruft. Damit wollen wir nachhaltiges und gerechtes Mobilitätsverhalten fördern.';
+
+  @override
+  String get the_project_content_bold_1 => 'SASIM';
+
+  @override
+  String get the_project_content_bold_2 => 'MCube';
+
+  @override
+  String get the_project_content_bold_3 => 'nachhaltige und transformative Mobilitätsinnovationen';
+
+  @override
+  String get the_project_content_bold_4 => 'wahren Kosten des urbanen Verkehrs';
+
+  @override
+  String get the_project_content_bold_5 => 'Luftschadstoffen, Klimaschäden, Unfälle, Stau, Flächenverbrauch, Zerschneidung und Lärm';
+
+  @override
+  String get the_project_content_bold_6 => 'nachhaltiges und gerechtes Mobilitätsverhalten';
+
+  @override
+  String get the_web_app => 'Die Web-App';
+
+  @override
+  String get the_web_app_content => 'Der bisherige Status Quo ist, dass die Kosten, die unser Mobilitätsverhalten verursacht, nicht gerecht verteilt werden. Momentan zahlen wir für unsere Mobilität nur die privaten, internen Kosten (z.B. Spritkosten, Ticketpreise oder Reparaturkosten), jedoch nicht die gesellschaftlichen, externen Kosten wie z.B. Unfallkosten oder Lärmkosten. Diese werden von der Gesellschaft getragen! Somit sind diejenigen, die durch ihr Mobilitätsverhalten hohe externe Kosten verursachen, genauso daran beteiligt wie die, die geringe Kosten verursachen.\n\nDieses frei verfügbare Online-Tool bewertet individuelle Wegeanfragen, je nach Verkehrmittel. Vorerst berechnet und bewertet das Tool nur Routen innerhalb der Stadt München.';
+
+  @override
+  String get the_web_app_content_bold_1 => 'nicht gerecht verteilt';
+
+  @override
+  String get the_web_app_content_bold_2 => 'nicht die gesellschaftlichen, externen Kosten';
+
+  @override
+  String get the_web_app_content_bold_3 => 'Dieses frei verfügbare Online-Tool bewertet individuelle Wegeanfragen, je nach Verkehrmittel.';
+
+  @override
+  String get the_mobi_score => 'Der Mobi-Score';
+
+  @override
+  String get the_mobi_score_content => 'Die Bewertung in diesem Tool berücksichtigt die Kosten für Luftschadstoffen, Klimaschäden, Unfälle, Stau, Flächenverbrauch, Zerschneidung und Lärm. Für jede Anfrage werden diese Kosten dann für jedes ausgewählte Verkehrsmittel anhand des MobiScores veranschaulicht.';
+
+  @override
+  String get the_mobi_score_content_bold_1 => 'Luftschadstoffen, Klimaschäden, Unfälle, Stau, Flächenverbrauch, Zerschneidung und Lärm';
+
+  @override
+  String get the_mobi_score_content_bullet_1 => 'Der MobiScore bewertet die wahren Kosten unserer individuellen Mobilität und schafft somit Bewusstsein für “unsichtbare“ Kosten';
+
+  @override
+  String get the_mobi_score_content_bullet_2 => 'Er gibt ein Indiz dafür, wie gerecht eigentlich bestimmte Verkehrsmittel für eine beliebige Strecke sind';
+
+  @override
+  String get the_team_behind => 'Wer steckt noch hinter Mobi-Score?';
+
+  @override
+  String get the_team_behind_content => 'Der Mobi-Score wurde im Rahmen des Forschungsprojekts SASIM von einem interdisziplinären Team aus fünf Lehrstühlen der Technischen Universität München (TUM) und mehreren externen Partnern entwickelt.';
+
+  @override
+  String get the_team_behind_content_hyperlink_1 => 'Forschungsprojekts SASIM';
+
+  @override
+  String get out_partners => 'Unsere Partner';
+
+  @override
+  String get personal_costs_research_content => 'Die Zahlen für die Berechnung der persönlichen Kosten basieren weitestgehend auf der Studie von König et al. (2021). Der Vollkostenrechner verwendet die folgenden Kostensätze (in Euro pro Personenkilometer, sofern nicht anders angegeben):';
+
+  @override
+  String get personal_costs_research_content_hyperlink_1 => 'König et al. (2021)';
+
+  @override
+  String get social_costs_research_content => 'Die Zahlen für die Berechnung der externen Kosten basieren auf der Studie von Schröder et. al (2023). Der Vollkostenrechner verwendet die folgenden Kostensätze (in Cent pro Personenkilometer):';
+
+  @override
+  String get social_costs_research_content_hyperlink_1 => 'Schröder et. al (2023)';
+
+  @override
+  String get routing_research => 'Routenplanung';
+
+  @override
+  String get routing_research_content => 'Der Vollkostenrechner nutzt die Software OpenTripPlanner (OTP) für die Routenplanung.\nAnhand der Eingaben (Start- und Zieladresse und gewähltes Verkehrsmittel) werden Distanz, Reisezeit und die Wegpunkte der Route berechnet.\n\nUm Routen und Fahrtkosten mit öffentlichen Verkehrsmitteln zu berechnen, wird über eine Schnittstelle auf das Fahrplaninformationssystems DEFAS zugegriffen.';
+
+  @override
+  String get development_by => 'Frontent und Backend Entwicklung von';
+
+  @override
+  String get illustrations_by => 'Illustrationen von';
+
+  @override
+  String get ui_by => 'UI/UX Design von';
+
+  @override
+  String get routing_research_content_hyperlink_1 => 'OpenTripPlanner (OTP)';
+
+  @override
+  String get routing_research_content_hyperlink_2 => 'DEFAS';
+
+  @override
+  String get want_to_help_us => 'Möchtest du uns helfen, besser zu werden?';
+
+  @override
+  String get want_to_help_us_explanation => 'Klicke auf den Button oder scanne den QR-Code, um an unserer Umfrage teilzunehmen. Dein Feedback ist uns wichtig!';
+
+  @override
+  String get to_the_survey => 'Zur Umfrage';
+
+  @override
+  String get mode_not_available => 'Das ausgewählte Verkehrsmittel ist für diese Route nicht verfügbar.';
+
+  @override
+  String get x_not_available => ' ist für diese Route nicht verfügbar.';
+
+  @override
+  String get try_another_route => 'Wenn du die wahren Kosten dieses Verkehrsmittels dennoch vergleichen willst, dann wähle eine andere Route';
+
+  @override
+  String get resume => 'Weiter';
+
+  @override
+  String get address_not_found_text => 'Diese Adresse konnte nicht gefunden werden. Liegt sie in München? Versuche es nochmal mit einer anderen Adresse!';
+}

--- a/flutter_frontend/multimodal_routeplanner/lib/l10n/app_localizations_en.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/l10n/app_localizations_en.dart
@@ -1,0 +1,694 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class AppLocalizationsEn extends AppLocalizations {
+  AppLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get that_are_the_true_costs_header => 'These are the true costs of your mobility';
+
+  @override
+  String get these_are_external_costs => 'These are the external costs of your route';
+
+  @override
+  String get what_is_mobi_score => 'What is the Mobi-Score?';
+
+  @override
+  String get calculator => 'Calculator';
+
+  @override
+  String get information => 'Information';
+
+  @override
+  String get about_us => 'About Us';
+
+  @override
+  String get start_address => 'Start Address';
+
+  @override
+  String get end_address => 'Destination Address';
+
+  @override
+  String get please_insert_address => 'Please insert address';
+
+  @override
+  String get from => 'From';
+
+  @override
+  String get from_hint => 'From (e.g. Arcisstraße 21, München)';
+
+  @override
+  String get to => 'To';
+
+  @override
+  String get to_hint => 'To (e.g. Ostbahnhof, München)';
+
+  @override
+  String get new_route => 'New Route';
+
+  @override
+  String get show_route => 'Show Route';
+
+  @override
+  String get car => 'Car';
+
+  @override
+  String get ecar => 'Electric Car';
+
+  @override
+  String get bike => 'Bike';
+
+  @override
+  String get ebike => 'Electric Bike';
+
+  @override
+  String get moped => 'Moped';
+
+  @override
+  String get e_moped => 'Electric Moped';
+
+  @override
+  String get tier => 'TIER E-Scooter';
+
+  @override
+  String get cab => 'Call a Bike';
+
+  @override
+  String get flinkster => 'Flinkster';
+
+  @override
+  String get emmy => 'Emmy';
+
+  @override
+  String get sharenow => 'Sharenow';
+
+  @override
+  String get pt => 'Public Transport';
+
+  @override
+  String get metro => 'Metro';
+
+  @override
+  String get tram => 'Tram';
+
+  @override
+  String get bus => 'Bus';
+
+  @override
+  String get e_bus => 'E-Bus';
+
+  @override
+  String get pt_and_bike => 'Public Transport + Bike';
+
+  @override
+  String get walk => 'Walk';
+
+  @override
+  String get not_available => 'Not Available';
+
+  @override
+  String get description_fullcosts => 'The total costs incurred when using a mode of transportation, including both direct and indirect costs such as fuel, maintenance, insurance, and environmental impacts.';
+
+  @override
+  String get description_external_costs => 'Costs incurred by using a mode of transportation but not directly borne by the users. These include environmental damage, health issues, and social costs.';
+
+  @override
+  String get description_internal_costs => 'The direct costs borne by users of a mode of transportation, such as fuel costs, maintenance, and insurance.';
+
+  @override
+  String get descripton_accidents => 'Accident costs are the costs arising from personal injuries in accidents. Since physical damage to cars and infrastructure is predominantly covered by motor vehicle insurance or borne by the parties causing the damage, they are not considered here.';
+
+  @override
+  String get description_air => 'The calculation of air pollution costs includes various aspects. These include material damage, crop failure, biodiversity loss, and health damage caused by air pollution.';
+
+  @override
+  String get description_noise => 'The effects of noise are noticeable in various areas of life. Thus, traffic noise causes costs for a national economy in several respects.';
+
+  @override
+  String get description_space => 'Transport uses land in two different traffic situations. Land is used for moving traffic via streets or rail systems. At the same time, vehicles that are not moved occupy space for parking.';
+
+  @override
+  String get description_congestion => 'Congestion is mostly known for blocked streets by cars and other road users. However, there are also a lot of congested public transport networks which lead to delays. For both cases, time is lost and thus costs are generated.';
+
+  @override
+  String get description_barrier => 'The barrier effect describes the time delay that motorized transport imposes on active mobility forms. This could be in the form of big streets pedestrians have to cross or circumvent to reach their destination.';
+
+  @override
+  String get description_environment => 'Costs due to environmental damage include all damages caused today and in the future by climate change, associated with uncertainties. They depend on the propulsion type of the vehicle and include costs from the operation of the vehicle as well as from the fuel and power production.';
+
+  @override
+  String get external_costs => 'external costs';
+
+  @override
+  String get internal_costs => 'internal costs';
+
+  @override
+  String get fullcosts => 'fullcosts';
+
+  @override
+  String get accidents => 'accidents';
+
+  @override
+  String get air_pollution => 'air pollution';
+
+  @override
+  String get noise => 'noise';
+
+  @override
+  String get space_use => 'space use';
+
+  @override
+  String get congestion => 'congestion';
+
+  @override
+  String get barrier_effects => 'barrier effects';
+
+  @override
+  String get environmental_damages => 'environmental\ndamages';
+
+  @override
+  String get mobi_score => 'Mobi-Score';
+
+  @override
+  String get header_external_costs => 'External\nCosts';
+
+  @override
+  String get header_internal_costs => 'Internal\nCosts';
+
+  @override
+  String get header_fullcosts => 'Full\nCosts';
+
+  @override
+  String get header_mobi_score => 'Mobi-\nScore';
+
+  @override
+  String get something_went_wrong => 'Something went wrong.';
+
+  @override
+  String get please_try_again => 'Please reload or select a different route.';
+
+  @override
+  String get try_again => 'Try again';
+
+  @override
+  String get research => 'Research';
+
+  @override
+  String get by => 'by';
+
+  @override
+  String get de => 'de';
+
+  @override
+  String get en => 'en';
+
+  @override
+  String get electric => 'Electric';
+
+  @override
+  String get calculate => 'Calculate';
+
+  @override
+  String get error => 'Error';
+
+  @override
+  String get show_detailed_info => 'Detailed Route Information';
+
+  @override
+  String get these_are_the_costs_of_your_journey_with => 'These are the real costs of mobility with';
+
+  @override
+  String get private_car => 'a private car';
+
+  @override
+  String get private_ecar => 'a private electric car';
+
+  @override
+  String get shared_car => 'car-sharing';
+
+  @override
+  String get private_bike => 'a private bike';
+
+  @override
+  String get private_ebike => 'a private electric bike';
+
+  @override
+  String get shared_bike => 'bike-sharing';
+
+  @override
+  String get public_transport => 'public transport';
+
+  @override
+  String get unknown => 'Unknown';
+
+  @override
+  String get fullcosts_of_trip => 'Fullcosts of the Trip';
+
+  @override
+  String get social_costs => 'Social Costs';
+
+  @override
+  String get social_costs_two_line => 'Social\nCosts';
+
+  @override
+  String get personal_costs => 'Personal Costs';
+
+  @override
+  String get personal_costs_two_line => 'Personal\nCosts';
+
+  @override
+  String get back_to_results => 'Back';
+
+  @override
+  String get share => 'Share or Leave some Feedback';
+
+  @override
+  String get time => 'Time';
+
+  @override
+  String get health => 'Health';
+
+  @override
+  String get environment => 'Environment';
+
+  @override
+  String get fixed => 'Fixed';
+
+  @override
+  String get variable => 'Variable';
+
+  @override
+  String get route_is_loading => 'Routes are loading...';
+
+  @override
+  String get learn_about => 'Learn about the true cost of your mobility';
+
+  @override
+  String get input_instructions => 'Choose among the available travel modes and enter a start and end point in Munich to calculate the true costs of your trip.';
+
+  @override
+  String get total_costs => 'Total Costs';
+
+  @override
+  String get total => 'Total';
+
+  @override
+  String get social => 'Social';
+
+  @override
+  String get overall => 'Overall';
+
+  @override
+  String get personal => 'Personal';
+
+  @override
+  String get time_costs => 'Time Costs';
+
+  @override
+  String get health_costs => 'Health Costs';
+
+  @override
+  String get environment_costs => 'Environment Costs';
+
+  @override
+  String get fixed_costs => 'Fixed Costs';
+
+  @override
+  String get variable_costs => 'Variable Costs';
+
+  @override
+  String get by_mode => 'by mode';
+
+  @override
+  String get total_description => 'The true costs - or full costs - of mobility are the sum of personal costs and external costs. The external costs are not carried by the traveler, but society as a whole.';
+
+  @override
+  String get social_description => 'Externalities arise when the activities of a person or company have an impact on third parties that are not included in the price. This effect can be both positive (external benefits) and negative (external costs). \nIn terms of mobility, external costs mean that the costs of transport activities are not carried by the travelers themselves, but by society in general.';
+
+  @override
+  String get personal_description => 'Personal costs – or internal costs - are borne by the users themselves. These internal costs can be both tangible and intangible. In terms of mobility, these might be monetary costs for vehicles (purchase, operation, disposal or repurchase) or for a public transport ticket.';
+
+  @override
+  String get detail_social_description => 'The external costs are clustered into three categories: time, health, and environment. The time dimension includes congestion costs and time losses due to barrier effects (infrastructure can also act as a physical barrier, requiring detours, for example, in the case of railways, a level crossing must be used). The health dimension includes the costs caused by noise, accidents, and air pollution. The environment dimension includes costs due to climate damage and space consumption.';
+
+  @override
+  String get detail_social_time_description => 'The time dimension includes congestion costs and time losses due to barrier effects.';
+
+  @override
+  String get what_are_congestion_costs => 'What are congestion costs?';
+
+  @override
+  String get detail_social_time_description_congestion => 'Congestion in road traffic or delays in public transport lead to time losses, which can be assessed in monetary terms with the help of willingness-to-pay approaches. Other negative effects of congestion are increased fuel consumption and wear and tear on roads and vehicles.\n\nThe total congestion costs for Munich (INRIX Traffic Scorecard) are allocated to individual modes of transport based on the space required and the vehicle kilometers traveled. In public transportation, average delays are used to calculate congestion costs.';
+
+  @override
+  String get what_are_barrier_costs => 'What are costs due to barrier effects?';
+
+  @override
+  String get detail_social_time_description_barrier => 'Wide road and rail routes with high traffic loads lead to restrictions for other forms of mobility. For example, pedestrians and cyclists must take detours to cross the infrastructure barrier. In addition, the spatial separation of districts can result in reduced economic productivity.\n\nThe monetary costs of these barrier effects have been estimated in various studies. Corresponding cost rates per vehicle kilometer have been adopted for the online tool.';
+
+  @override
+  String get detail_social_health_description => 'The health dimension includes the costs caused by noise, accidents, and air pollution.';
+
+  @override
+  String get what_are_noise_costs => 'What are noise costs?';
+
+  @override
+  String get detail_social_health_description_noise => 'Noise from road and rail traffic causes disturbances and harms human health. This causes damage to society in the form of loss of value of real estate, reduced quality of life, as well as treatment costs and productivity losses due to physical, cognitive, or psychological impairments.\n\nThe amount of the noise costs is determined by the number of persons affected per level class, measured in dB(A). The total costs are then divided among the individual means of transport using weighting factors and mileage.';
+
+  @override
+  String get what_are_accident_costs => 'What are accident costs?';
+
+  @override
+  String get detail_social_health_description_accidents => 'Traffic accidents cause medical costs, property damage, losses due to work absences, administrative expenses, and intangible costs (e.g., suffering and shock).\n\nOnly personal injury is included when calculating external costs, as property damage is largely covered by motor vehicle insurance and is therefore part of the personal costs.\nThe police accident statistics provide information on the accident’s severity, road users involved, and the causer.\n\nWith the help of appropriate cost rates, the total cost of each accident can be determined. The accident costs are allocated to the modes of transport according to the polluter pays principle (costs are allocated to the mode of transport causing the accident) and the damage potential principle (allocation is based on mass and speed).';
+
+  @override
+  String get what_are_air_costs => 'What are costs due to air pollution';
+
+  @override
+  String get detail_social_health_description_air => 'Air pollution occurs both in vehicle operation through fuel combustion and abrasion and during fuel production. The consequences are material damage (e.g. to buildings), crop damage, biodiversity loss and damage to health (especially due to respiratory diseases).\n\nThe cost rates for various air pollutants, such as particulate matter, nitrogen oxides or ammonia, come from the Federal Environment Agency\'s Methodological Convention 3.1.\n';
+
+  @override
+  String get detail_social_environment_description => 'The environment dimension includes costs due to climate damage and space consumption.';
+
+  @override
+  String get what_are_climate_costs => 'What are costs due to climate damage?';
+
+  @override
+  String get detail_social_environment_description_climate => 'Greenhouse gas emissions are generated during fuel combustion in the vehicle and during the production of fuels and energy. In the atmosphere, greenhouse gases lead to a change in the climate – with negative consequences for ecosystems, human health, and food production.\n\nThe Federal Environment Agency recommends the damage cost approach for determining climate damage. This involves estimating the damage caused by a given amount of greenhouse gases emitted. For this purpose, greenhouse gases such as carbon dioxide, methane, and nitrous oxide are converted into CO2 equivalents.';
+
+  @override
+  String get what_are_space_costs => 'What are costs due to space consumption?';
+
+  @override
+  String get detail_social_environment_description_space => 'Transportation needs space for driving and parking. The calculations in this online tool consider the city of Munich’s investments in road traffic, public transport, and bicycle traffic. In addition, so-called opportunity costs arise, as the space cannot be used for other purposes. In the case of cars, the costs for construction and maintenance of parking, as well as the income from parking fees, are also considered.';
+
+  @override
+  String get detail_personal_description => 'These costs consist of fixed costs and variable costs. Fixed costs include costs such as vehicle depreciation. The variable costs are kilometre-dependent costs, such as fuel costs. The cost rates for bicycles and e-bikes include depreciation (fixed costs) as well as tyres, maintenance/repairs and electricity costs (variable costs). The fixed costs for the car include the subcategories depreciation, insurance, tax, MOT and parking. The variable costs include fuel costs, maintenance, repairs, tyres and care.';
+
+  @override
+  String get detail_personal_fixed_description => 'Fixed costs include costs such as the depreciation of vehicles.';
+
+  @override
+  String get detail_personal_variable_description => 'Variable costs are kilometer-dependent costs, such as fuel costs.';
+
+  @override
+  String get get_started => 'Start Full Cost Calculation';
+
+  @override
+  String get diagram => 'Diagram';
+
+  @override
+  String get about_us_title => 'About Us';
+
+  @override
+  String get about_us_content => 'We are an interdisciplinary team consisting of five chairs from TU Munich and several external partners.\n\nOur goal is to transparently present and communicate the true costs of urban traffic in Munich.\n\nWe want to raise awareness of the costs of air pollutants, climate damage, accidents, congestion, land consumption, and noise caused by our mobility.\n\nWith this, we aim to promote sustainable and fair mobility behavior.';
+
+  @override
+  String get research_content => 'The full cost calculator uses scientific methods to enable a cost comparison of different forms of mobility.';
+
+  @override
+  String get note_address => '*Please only enter addresses in Munich, otherwise not every route can be calculated.';
+
+  @override
+  String get mode_of_transport => 'mode';
+
+  @override
+  String get reload => 'Reload';
+
+  @override
+  String get error_empty => 'Enter an address.';
+
+  @override
+  String get error_shorter_than_2 => 'Enter a longer address.';
+
+  @override
+  String get copy_url => 'Copy URL';
+
+  @override
+  String get url_copied => 'URL copied to clipboard';
+
+  @override
+  String get tell_a_friend => 'Do you like Mobi-Score? Tell a friend!';
+
+  @override
+  String get field_empty_alert => 'The address field cannot be empty';
+
+  @override
+  String get input_short_alert => 'Input must be longer than 2 characters';
+
+  @override
+  String get shared => 'Sharing';
+
+  @override
+  String get private => 'Private';
+
+  @override
+  String get header_image_label => 'The title image shows an urban scene with multiple modes of transport: a teal bus, a cyclist on a teal bicycle, and an elevated white-and-orange train. People are walking in the background, and a large profile of a woman with dark hair is shown to the right, overlooking the city. The city has modern buildings, greenery, and statues.';
+
+  @override
+  String get what_are => 'What are';
+
+  @override
+  String get start_new_route => 'Start a new route';
+
+  @override
+  String get mobi_score_description_1 => 'In addition to private, internal costs (e.g. fuel costs or insurance), our individual mobility also causes external costs such as accident costs or noise costs. The Mobi-Score assesses precisely these external costs of our individual mobility. It is intended to raise awareness of the fact that the costs of our mobility are not distributed fairly - as there are costs that are not borne by the person who causes them, but by society as a whole.';
+
+  @override
+  String get mobi_score_description_2 => 'The Mobi-Score depends on the chosen mode of transport and the distance traveled. This can vary significantly between different modes of transport.';
+
+  @override
+  String get mobi_score_description_3 => 'If a route has comparatively high external costs, it receives the Mobi-Score E (red). On the other hand, if the route has low external costs, it receives the Mobi-Score A (green).';
+
+  @override
+  String get imprint => 'Imprint';
+
+  @override
+  String get imprint_content => 'Munich Cluster for the Future of Mobility in Metropolitan Regions (MCube)';
+
+  @override
+  String get contact_details => 'Contact Details';
+
+  @override
+  String get contact => 'Publisher';
+
+  @override
+  String get imprint_contact_details_content => 'Technical University Munich\nTUM School of Engineering and Design\nChair of Urban Structure and Transport Planning\nArcisstraße 21\n80333 Munich';
+
+  @override
+  String get authorized_to_represent => 'Authorized to Represent';
+
+  @override
+  String get imprint_authorized_content => 'The Technical University of Munich is legally represented by the President, Prof. Dr. Thomas F. Hofmann.\nThe Technical University of Munich is, according to Art. 11 para. 1 sentence 1 BayHSchG, a public corporation with the right of self-administration within the framework of the laws and at the same time, according to Art. 1 para. 2 sentence 1 no. 1 BayHSchG, a state university (state institution). The Technical University of Munich handles its own matters as a corporation (corporate matters) under the legal supervision of the supervisory authority and state matters as a state institution (Art. 12 para. 1 BayHSchG).\nVAT DE811193231 (in accordance with § 27a of the Value Added Tax Act)';
+
+  @override
+  String get responsible_for_content => 'Responsible for Content';
+
+  @override
+  String get imprint_responsible_content => 'Julia Kinigadner\nE-Mail: sasim@mcube-cluster.com';
+
+  @override
+  String get more_information => 'More information at:';
+
+  @override
+  String get more_information_content => 'www.mcube-cluster.de\nhttps://www.mos.ed.tum.de/sv';
+
+  @override
+  String get disclaimer => 'Disclaimer';
+
+  @override
+  String get imprint_disclaimer_content => 'Despite careful content control, we assume no liability for the content of external links. The operators of the linked pages are solely responsible for their content. Articles marked by name in the discussion areas reflect the author\'s opinion. The authors are solely responsible for the content of their contributions.';
+
+  @override
+  String get privacy_policy => 'Privacy Policy';
+
+  @override
+  String get general_information => 'General Information';
+
+  @override
+  String get privacy_general_content => 'We take the protection of your personal data very seriously and treat your personal information confidentially and in accordance with legal data protection regulations as well as this privacy policy. This app does not require registration and does not store any personal data.';
+
+  @override
+  String get responsible_person => 'Responsible Person';
+
+  @override
+  String get privacy_responsible_content => 'The entity responsible for data processing in accordance with the General Data Protection Regulation (GDPR) is:\n\nMCube\nFreddie-Mercury-Straße 5\n80797 Munich\nPhone: +49 89 289-01\nE-Mail: sasim@mcube-cluster.com';
+
+  @override
+  String get collection_and_processing_personal_data => 'Collection and Processing of Personal Data';
+
+  @override
+  String get privacy_collection_content => 'No personal data is stored or processed in the SASIM app. The use of the app does not require registration, and no user data that allows identification is stored.';
+
+  @override
+  String get processing_user_data => 'Processing of User Data';
+
+  @override
+  String get privacy_processing_content => 'The app only processes start and destination addresses entered by the user for routing purposes. These addresses are stored anonymously with a timestamp in log files, without any personal reference. This data is only used to provide the requested service and is not stored permanently.';
+
+  @override
+  String get third_party_services => 'Third-Party Services';
+
+  @override
+  String get photon_header => 'Photon API';
+
+  @override
+  String get privacy_photon_content => 'For geocoding addresses, the Photon API is used, which is licensed under the **Apache License, Version 2.0**. For more information about Photon API and its licensing, please visit: https://photon.komoot.io/.';
+
+  @override
+  String get efa_header => 'EFA API of MVV';
+
+  @override
+  String get privacy_efa_content => 'For route planning and finding transportation options, we use the **EFA API** from the Munich Transport and Tariff Association (MVV). Through this API, information about public transport and sharing services from **ShareNow** and **Call a Bike** is provided. No personal data is stored or passed on to these providers.';
+
+  @override
+  String get data_security => 'Data Security';
+
+  @override
+  String get privacy_security_content => 'We implement technical and organizational measures to ensure the security of the data processed by the app. As no personal data is stored, the risk of a data protection breach is minimal.';
+
+  @override
+  String get cookies => 'Cookies';
+
+  @override
+  String get privacy_cookies_content => 'This app does not use cookies or similar tracking technologies.';
+
+  @override
+  String get your_rights => 'Your Rights';
+
+  @override
+  String get privacy_rights_content => 'Since no personal data is processed in this app, the rights of access, rectification, deletion, or restriction of processing according to Art. 15-18 GDPR are not applicable. If you still have questions regarding data protection in relation to the use of the app, you can contact us using the above contact information.';
+
+  @override
+  String get changes_to_privacy_policy => 'Changes to this Privacy Policy';
+
+  @override
+  String get privacy_changes_content => 'We reserve the right to adjust this privacy policy to ensure it always complies with current legal requirements or to reflect changes to the app. Users will be informed of any changes in due time.';
+
+  @override
+  String get the_project => 'The Project';
+
+  @override
+  String get the_project_content => 'This tool was developed as part of the SASIM research project, which is one of 14 projects in the first implementation phase of the Munich Cluster for the Future of Mobility in Metropolitan Regions (MCube). MCube is a future cluster funded by the BMBF, aiming to establish sustainable and transformative mobility innovations.\n\nOur goal is to make the true costs of urban transportation transparent and communicate them effectively. We aim to raise awareness about the costs of air pollutants, climate damage, accidents, traffic congestion, land use, and noise generated by our mobility. By doing so, we want to promote sustainable and fair mobility behavior.';
+
+  @override
+  String get the_project_content_bold_1 => 'SASIM';
+
+  @override
+  String get the_project_content_bold_2 => 'MCube';
+
+  @override
+  String get the_project_content_bold_3 => 'sustainable and transformative mobility innovations';
+
+  @override
+  String get the_project_content_bold_4 => 'true costs of urban transportation';
+
+  @override
+  String get the_project_content_bold_5 => 'air pollutants, climate damage, accidents, traffic congestion, land use, and noise';
+
+  @override
+  String get the_project_content_bold_6 => 'sustainable and fair mobility behavior';
+
+  @override
+  String get the_web_app => 'The Web App';
+
+  @override
+  String get the_web_app_content => 'The current status quo is that the costs caused by our mobility behavior are not fairly distributed. At the moment, we only pay for the private, internal costs of our mobility (e.g. fuel costs, ticket prices, or repair costs), but not the societal, external costs such as accident costs or noise costs. These are borne by society! Thus, those who cause high external costs through their mobility behavior are just as involved as those who cause low costs.\n\nThis freely available online tool evaluates individual route requests depending on the means of transportation. For now, the tool only calculates and evaluates routes within the city of Munich.';
+
+  @override
+  String get the_web_app_content_bold_1 => 'not fairly distributed';
+
+  @override
+  String get the_web_app_content_bold_2 => 'not the societal, external costs';
+
+  @override
+  String get the_web_app_content_bold_3 => 'This freely available online tool evaluates individual route requests depending on the means of transportation.';
+
+  @override
+  String get the_mobi_score => 'The Mobi-Score';
+
+  @override
+  String get the_mobi_score_content => 'The evaluation in this tool takes into account the costs of air pollutants, climate damage, accidents, traffic congestion, land use, and noise. For each request, these costs are then illustrated for each selected mode of transport using the MobiScore.';
+
+  @override
+  String get the_mobi_score_content_bold_1 => 'air pollutants, climate damage, accidents, traffic congestion, land use, and noise';
+
+  @override
+  String get the_mobi_score_content_bullet_1 => 'The MobiScore evaluates the true costs of our individual mobility and raises awareness of “invisible” costs.';
+
+  @override
+  String get the_mobi_score_content_bullet_2 => 'It provides an indication of how fair certain modes of transport are for any given route.';
+
+  @override
+  String get the_team_behind => 'Who else is behind Mobi-Score?';
+
+  @override
+  String get the_team_behind_content => 'The Mobi-Score was developed as part of the SASIM research project by an interdisciplinary team of five chairs from the Technical University of Munich (TUM) and several external partners.';
+
+  @override
+  String get the_team_behind_content_hyperlink_1 => 'SASIM research project';
+
+  @override
+  String get out_partners => 'Our Partners';
+
+  @override
+  String get personal_costs_research_content => 'The calculations of personal costs are largely based on the study by König et al. (2021). The full cost calculator uses the following cost rates (in euros per passenger-kilometer, unless otherwise stated):';
+
+  @override
+  String get personal_costs_research_content_hyperlink_1 => 'König et al. (2021)';
+
+  @override
+  String get social_costs_research_content => 'The calculations of external costs are based on the study by Schröder et. al (2023). The full cost calculator uses the following cost rates (in cents per passenger-kilometer):';
+
+  @override
+  String get social_costs_research_content_hyperlink_1 => 'Schröder et al. (2023)';
+
+  @override
+  String get routing_research => 'Routing';
+
+  @override
+  String get routing_research_content => 'The full cost calculator uses the software OpenTripPlanner (OTP) for route planning.\nBased on the inputs (start and destination address and selected travel mode), distance, travel time and the waypoints of the route are calculated.\n\nIn order to calculate routes and travel costs by public transportation, the timetable information system DEFAS is accessed via an API.';
+
+  @override
+  String get development_by => 'Frontent und Backend Development by';
+
+  @override
+  String get illustrations_by => 'Illustrations by';
+
+  @override
+  String get ui_by => 'UI/UX Design by';
+
+  @override
+  String get routing_research_content_hyperlink_1 => 'OpenTripPlanner (OTP)';
+
+  @override
+  String get routing_research_content_hyperlink_2 => 'DEFAS';
+
+  @override
+  String get want_to_help_us => 'Want to help us improve?';
+
+  @override
+  String get want_to_help_us_explanation => 'Click on the button below or scan the QR code to participate in our survey. Your feedback is important to us!';
+
+  @override
+  String get to_the_survey => 'To the survey';
+
+  @override
+  String get mode_not_available => 'This mode of transportation is not available for this route.';
+
+  @override
+  String get x_not_available => ' is not available for this route.';
+
+  @override
+  String get try_another_route => 'If you still want to compare the true costs of this mode of transportation, please choose another route';
+
+  @override
+  String get resume => 'Weiter';
+
+  @override
+  String get address_not_found_text => 'This address could not be found. Is it located in Munich? Try again with a different one!';
+}

--- a/flutter_frontend/multimodal_routeplanner/lib/main.dart
+++ b/flutter_frontend/multimodal_routeplanner/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:multimodal_routeplanner/01_presentation/theme_data/color_schemes.g.dart';
 import 'package:multimodal_routeplanner/01_presentation/theme_data/typography.dart';
@@ -17,6 +16,7 @@ import 'package:multimodal_routeplanner/config/setup_dependencies.dart';
 
 import '02_application/bloc/route_info/route_info_bloc.dart';
 import '02_application/bloc/visualization/visualization_bloc.dart';
+import 'l10n/app_localizations.dart';
 
 void main() async {
   setupDependencies();

--- a/flutter_frontend/multimodal_routeplanner/pubspec.lock
+++ b/flutter_frontend/multimodal_routeplanner/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   code_builder:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -253,10 +253,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   fancy_shimmer_image:
     dependency: "direct main"
     description:
@@ -449,10 +449,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -497,26 +497,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -553,26 +553,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.16.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -617,10 +617,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_provider:
     dependency: transitive
     description:
@@ -777,7 +777,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_gen:
     dependency: transitive
     description:
@@ -830,18 +830,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -878,10 +878,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.6"
   timing:
     dependency: transitive
     description:
@@ -982,10 +982,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -1059,5 +1059,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <=3.4.3"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.22.0"

--- a/flutter_frontend/multimodal_routeplanner/pubspec.yaml
+++ b/flutter_frontend/multimodal_routeplanner/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0 <=3.4.3"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   bloc: ^8.0.3
@@ -71,4 +71,5 @@ flutter:
     - assets/flags/
     - assets/partners_logos/
     - assets/research_data/
+    - lib/l10n/
 


### PR DESCRIPTION
Fix address encoding for Photon API responses

- Updated the Photon datasource to decode API responses using UTF-8, ensuring correct display of special characters (e.g., "München").
- Verified that the address picker only returns results for Munich.
